### PR TITLE
modified util.apply_columns and added util.mutate_many

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -59,7 +59,7 @@ util.apply_columns <- function(df, fun, col_names = NULL, ...){
 util.mutate_many <- function(df,
     col_names,
     fun,
-    append = TRUE,
+    replace = FALSE,
     newcol_names = NULL,
     ...){
     # imitates the behavior of mutate in that it returns a data.frame of the
@@ -70,20 +70,20 @@ util.mutate_many <- function(df,
     # columns in df
     df_cols_mutated <- util.apply_columns(df, fun, col_names, ...)
 
-    if(append){
-        if(is.null(newcol_names)){
-            # if append is true and there are no new column names set, rename
-            # the mutated columns (to avoid duplicated column names).
-            newcol_names <- paste0(col_names, "_new")
-        }
-    } else{
-        # if append is false, remove the original columns from df before
+    if(replace){
+        # if replace is TRUE, remove the original columns from df before
         # appending the new columns
         df <- df[!names(df) %in% col_names]
         # it's also safe to set the new column names to the old column names if
         # newcol_names are not defined.
         if(is.null(newcol_names)){
             newcol_names <- col_names
+        }
+    } else{
+        if(is.null(newcol_names)){
+            # if append is true and there are no new column names set, rename
+            # the mutated columns (to avoid duplicated column names).
+            newcol_names <- paste0(col_names, "_new")
         }
     }
     # rename the mutated columns


### PR DESCRIPTION
As we discussed today, I modified `util.apply_columns`. However, I did it a bit differently than how we discussed:
- I did add a parameter to `util.apply_columns` allowing the user to restrict the function to select columns, because I think a person using this function a la carte might appreciate that parameter.
- However, I made `util.apply_columns` always, only return the columns to which the function was applied.
- I then wrote a separate function (which I've called `util.mutate_many` but I'm not married to that) to handle the logic of all the various ways you might want to use `util.apply_columns`. For example, you might want to replace the old columns in the data.frame with the modified ones or not, or you might have new column names you want to use or not.

My reasoning in breaking it up this way was that util.apply_columns seems like a nice, simple function with predictable output, whereas the logic of replacing/renaming columns is more complicated. But I could also just combine these two functions -- I'm interested to hear what you think.
