### PR TITLE
extremely minor change: fixed util.print_pre and util.html_table to work in for-loops

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -169,11 +169,14 @@ util.as_numeric_if_number <- function(x){
 
 util.print_pre <- function(x){
     # prints to html as it would to console (preformatted html)
-    if(interactive()) return(x)
-    capture.output(print(x)) %>%
+    if(interactive()){
+        print(x)
+    } else{
+        capture.output(print(x)) %>%
         paste(collapse="\n") %>%
         paste("<pre>",.,"</pre>") %>%
         cat()
+    }
 }
 
 util.warn <- function(message) {
@@ -248,7 +251,7 @@ util.html_table_data_frame <- function(x){
                             "border=0, class='xtable'")
         )
     }else{
-        return(x)
+        print(x)
     }
 }
 


### PR DESCRIPTION
I made an extremely minor change to util.html_table and util.print_pre. When in interactive mode only, instead of simply returning the data object, I have these functions print the object. The reason is because `return()` does not cause objects to get printed to the console in the context of for-loops, which is annoying. So I changed `return()` to `print()` for interactive mode only -- that's literally all I did.

Rumen and I couldn't imagine a case when you'd want to use either of these functions for variable assignment that would truly require a return, but I want to run it by you in case you had a reason for returning the object that I'm not thinking of. 