### PR TITLE
listing files and finding in crypts

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -608,12 +608,9 @@ util.find_crypt_paths <- function (files_to_load, initial_path = NA,
     for (label in names(files_to_load)) {
         file_name <- files_to_load[[label]]
 
-        # Make sure the file name starts with a slash so that, when grepping, we
-        # don't match in the middle of a file or folder name.
-        if (substr(file_name, 1, 1) != '/') {
-            file_name <- '/' %+% file_name
-        }
-        match <- crypt_files[grepl(file_name, crypt_files)]
+        # fixed = TRUE means interpret the file name as a literal subset to match,
+        # not a regular expression (where characters like . have special meaning).
+        match <- crypt_files[grepl(file_name, crypt_files, fixed = TRUE)]
         if (length(match) > 1) {
             stop("Multiple matches found for " %+% file_name %+% ": " %+%
                  match %+% "\n")

--- a/R/util.R
+++ b/R/util.R
@@ -533,7 +533,7 @@ util.list_files <- function (initial_path, max_depth = 2, current_depth = 0) {
     # Returns: char of absolute file paths
 
     if (.Platform$OS.type != 'unix') {
-        stop("list_files() only supports unix-like systems, not windows.")
+        stop("util.list_files() only supports unix-like systems, not windows.")
     }
 
     # List everything within this path, both files and dirs.
@@ -553,7 +553,7 @@ util.list_files <- function (initial_path, max_depth = 2, current_depth = 0) {
     # If not at max depth, recurse into each found directory.
     if (current_depth < max_depth) {
         for (d in dirs) {
-            files <- c(files, list_files(
+            files <- c(files, util.list_files(
                 d, max_depth = max_depth, current_depth = current_depth + 1))
         }
     }
@@ -589,7 +589,7 @@ util.find_crypt_paths <- function (files_to_load, initial_path = '/Volumes',
     # Compile a list of files from each mount path.
     crypt_files <- c()
     for (m in mount_paths) {
-        crypt_files <- c(list_files(m), crypt_files)
+        crypt_files <- c(util.list_files(m), crypt_files)
     }
 
     # For each file to load, scan the list of known files for a match.

--- a/R/util.R
+++ b/R/util.R
@@ -560,8 +560,8 @@ util.list_files <- function (initial_path, max_depth = 2, current_depth = 0) {
     return(files)
 }
 
-util.find_crypt_paths <- function (files_to_load, initial_path = '/Volumes',
-                              max_depth = 2) {
+util.find_crypt_paths <- function (files_to_load, initial_path = NA,
+                                   volume_patterns = NA) {
     # Find the full paths of specified files within any mounted crypts.
     # Designed to work with util.read_csv_files().
     #
@@ -578,13 +578,24 @@ util.find_crypt_paths <- function (files_to_load, initial_path = '/Volumes',
     #     e.g. 'CC10-11/data.csv'
     #   initial_path: atomic char, default '/Volumes', the parent directory
     #     where crypt files are mounted.
+    #   volume_patterns: char, regexes that are expected to match volume names.
+    #     Default matches volumes that start with "NO NAME" or "Untitled".
     #   max_depth: atomic int, default 2, how many subfolders deep to scan for
     #     files. Zero means enter no subfolders.
     #
     # Returns: List with provided labels to absolute file paths.
 
+    if (is.na(initial_path)) {
+        initial_path = '/Volumes'
+    }
+    if (is.na(volume_patterns)) {
+        volume_patterns = c('NO.NAME', 'Untitled')
+    }
+    pattern <- '(' %+% paste(volume_patterns, collapse = '|') %+% ')'
+
     all_volume_paths <- list.dirs(initial_path, recursive = FALSE)
-    mount_paths <- all_volume_paths[grepl('/NO NAME', all_volume_paths)]
+    mount_paths <- all_volume_paths[grepl(
+        pattern, ignore.case = TRUE, all_volume_paths)]
 
     # Compile a list of files from each mount path.
     crypt_files <- c()


### PR DESCRIPTION
@daveponet fyi: tool for making it easier to find you data files in mounted crypts, regardless of which slot you have them in, for immediate use with CTC analysts.

## Background

People are used to operating on deidentified data in the R scripts. These are not in crypt files, so the path to the data is static, e.g. `~/Dropbox/PERTS shared data/something/something`. We're changing things up and making everyone keep everything in crypts. This is annoying because the path to your data can change depending on which slot you mount it in.

## Implementation

This code solves that problem. Assuming 1) you're not using a Windows computer 2) your VeraCrypt mounts things in `/Volumes/NO NAME[ X]`, you just need to give the file name in order to load the file.

The function is designed to operate smoothly with util.read_csv_files, so you can write something like this:

```
my_data <- util.read_csv_files(util.find_crypt_files(list(
  cc10 = "CC10/all_students.csv",
  ku51 = "KU/5-1/cool_stuff.csv"
)))
```

You only need to write as much of the file path as is necessary to uniquely identify the file, and the files might be spread across arbitrary mount points.