### PR TITLE
List files

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -514,42 +514,65 @@ util.assign_list_to_environment <- function(l, environment = .GlobalEnv){
     }
 }
 
-util.list_files <- function (initial_path, max_depth = 2, current_depth = 0) {
+util.list_all <- function (initial_path, max_depth = 2, type = 'all', current_depth = 0) {
     # Like base::list.files, but better:
-    # * Lists files, not directories. Because it's called list_files.
+    # * Can choose to list only files, not directories (type = 'files').
     # * Rather than choosing between no recursion (not very useful) and full
     #   recursion (potentially very slow for a deep folder tree) you can set a
     #   max depth. Choose 0 for no recursion.
     # * Ignores hidden and system files, defined as anything starting with
     #   '.', '$', or '~'.
-    # * Only works on unix-like systems (no windows)!
     #
     # Args:
     #   initial_path: atomic char, directory to scan for files.
     #   max_depth: atomic int, default 2, how many subfolders deep to scan for
     #     files. Zero means enter no subfolders.
-    # current_depth: internal use only, do not specify.
+    #   type: atomic char, default 'all', or choose 'dirs' or 'files'.
+    #   current_depth: internal use only, do not specify.
     #
     # Returns: char of absolute file paths
     
+    # Remove the trailing slash if it exists.
+    len <- nchar(initial_path)
+    if (substr(initial_path, len, len) == '/') {
+        initial_path <- substr(initial_path, 1, len - 1)
+    }
     
     # List everything within this path, both files and dirs.
     all_names <- list.files(initial_path, pattern = '^[^\\.\\$~]',
-                            full.names = TRUE)
+                            full.names = TRUE, recursive = FALSE)
     
     # file.info() returns a data frame, use it to separate files and dirs.
     info <- file.info(all_names)
-    files <- all_names[!info$isdir]
-    dirs <- all_names[info$isdir]
+    dirs <- all_names[info$isdir %in% TRUE]  # careful, isdir can be NA
+    files <- all_names[info$isdir %in% FALSE]
+
+    if (type == 'files') {
+        out <- files
+    } else if (type == 'dirs') {
+        out <- dirs
+    } else {
+        out <- all_names
+    }
     
     # If not at max depth, recurse into each found directory.
     if (current_depth < max_depth) {
         for (d in dirs) {
-            files <- c(files, util.list_files(
-                d, max_depth = max_depth, current_depth = current_depth + 1))
+            out <- c(out, util.list_all(
+                d, max_depth = max_depth, type = type,
+                current_depth = current_depth + 1))
         }
     }
-    return(files)
+
+    return(out)
+}
+
+util.list_files <- function (initial_path, ...) {
+    util.list_all(initial_path, type = 'files', ...)
+}
+
+util.list_dirs <- function (initial_path, ...) {
+    util.list_all(initial_path, type = 'dirs', ...)
 }
 
 util.find_crypt_paths <- function (files_to_load, initial_path = NA,

--- a/R/util.R
+++ b/R/util.R
@@ -625,9 +625,9 @@ util.find_crypt_paths <- function (files_to_load, initial_path = NA,
     }
 
     # Compile a list of files from each mount path.
-    crypt_files <- c()
+    crypt_paths <- c()
     for (m in mount_paths) {
-        crypt_files <- c(util.list_files(m), crypt_files)
+        crypt_paths <- c(util.list_all(m), crypt_paths)
     }
 
     # For each file to load, scan the list of known files for a match.
@@ -635,10 +635,14 @@ util.find_crypt_paths <- function (files_to_load, initial_path = NA,
     for (label in names(files_to_load)) {
         file_name <- files_to_load[[label]]
 
-        # fixed = TRUE means interpret the file name as a literal subset to
-        # match, not a regular expression (where characters like . have special
-        # meaning).
-        match <- crypt_files[grepl(file_name, crypt_files, fixed = TRUE)]
+        # We only want to match the end of the path, whether it's a file or a
+        # directory, so trim everything to the length of the file name before
+        # checking for an exact match.
+        p_len <- nchar(file_name)  # pattern length
+        s_len <- nchar(crypt_paths)  # subject length
+        crypt_path_endings <- substr(crypt_paths, s_len - p_len + 1, s_len)
+
+        match <- crypt_paths[crypt_path_endings == file_name]
         if (length(match) > 1) {
             stop("Multiple matches found for " %+% file_name %+% ": " %+%
                  match %+% "\n")


### PR DESCRIPTION
fyi @daveponet 

As I started to use these listing functions, I realized I needed more flexibility to find files sometimes, directories sometimes, and sometimes both. This cleans up the functions so they can be used more flexibly.

`util.list_all()` lists both files and directories within `max_depth` of some initial path.
`util.list_files()` is the same, but lists just files.
`util.list_dirs()` is the same, but lists just directories.

`util.find_crypt_paths()` now can also find directories within crypts, not just files.