### PR TITLE
options in util.html_table

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -218,7 +218,7 @@ util.passed <- function(message) {
 ###############################################################
 
 
-util.html_table_from_model <- function(model){
+util.html_table_from_model <- function(model, ...){
     accepted_models <- c("lmerMod","lm","aov","glm","glmerMod")
     if( ! any(class(model) %in% accepted_models ) ){
         util.warn("Unaccepted model supplied!")
@@ -231,7 +231,8 @@ util.html_table_from_model <- function(model){
             notes        = "",
             notes.label = "1 star p<.05; 2 stars p<.01; 3 stars p<.001",
             notes.append = FALSE,
-            single.row=TRUE
+            single.row=TRUE,
+            ...
         )
     }
     else{
@@ -239,7 +240,7 @@ util.html_table_from_model <- function(model){
     }
 }
 
-util.html_table_data_frame <- function(x){
+util.html_table_data_frame <- function(x, ...){
     # "grouped_df", "tbl_df" are dplyr type data.frames
     # ungroup to make them printable like a data.frame
     if(any(class(x) %in% c("grouped_df", "tbl_df"))){
@@ -252,34 +253,44 @@ util.html_table_data_frame <- function(x){
               include.rownames = FALSE,
               html.table.attributes =
                   getOption("xtable.html.table.attributes",
-                            "border=0, class='xtable'")
+                            "border=0, class='xtable'"),
+              ...
         )
     }else{
         print(x)
     }
 }
 
-util.html_table_psych_alphas <- function(x){
+util.html_table_psych_alphas <- function(x, ...){
     # psych::alpha object, turn key data into data.frame
     if(! all(class(x) %in% c("psych","alpha"))){
         util.warn("Not a psych::alpha object!")
     }
     # extract the alpha coefficients for printing
     x <- x$total
-    util.html_table_data_frame(x)
+    util.html_table_data_frame(x, ...)
 }
 
 util.html_table <- function(x, ...) {
+    # Print a variety of things to rendered output as a nice table.
+    # Accepts extra keyword arguments which are passed to xtable or stargazer,
+    # as appropriate.
+    # To capture rendered output in non-interactive mode as a character vector:
+    # * Nothing is required in the case of models, just assign the returned
+    #   value, e.g. `output <- util.html_table(lm.D9)`
+    # * Set `print.results = FALSE` in other cases, e.g.
+    #   `output <- util.html_table(my_data_frame, print.results = FALSE)`
+    #   `output <- util.html_table(psych::alpha(r9), print.results = FALSE)`
     accepted_models <- c("lmerMod","lm","aov","glm","glmerMod")
     accepted_psych_objects <- c("psych","alpha")
     accepted_dfs <- c("grouped_df", "tbl_df","data.frame","table")
 
     if( any(class(x) %in% accepted_models ) ){
-        util.html_table_from_model(x)
+        util.html_table_from_model(x, ...)
     } else if( all( class(x) %in% accepted_psych_objects ) ){
-        util.html_table_psych_alphas(x)
+        util.html_table_psych_alphas(x, ...)
     } else if( any(class(x) %in% accepted_dfs ) ){
-        util.html_table_data_frame(x)
+        util.html_table_data_frame(x, ...)
     }
 }
 


### PR DESCRIPTION
We want to have more flexibility with sending data to templates instead of rendering it immediately. This makes use of the existing `...` in `util.html_table()` by passing it to the relevant library calls.

Also adds documentation on how to use the `print.results = F` option, specifically useful for templates.

## Testing

I'm not very familiar with the model- and alpha-based uses of this function, but I looked up the library documentation and tried these uses from the examples:

```
r4 <- sim.congeneric()
output <- util.html_table(psych::alpha(r4), print.results = FALSE)
```

```
ctl <- c(4.17,5.58,5.18,6.11,4.50,4.61,5.17,4.53,5.33,5.14)
trt <- c(4.81,4.17,4.41,3.59,5.87,3.83,6.03,4.89,4.32,4.69)
group <- gl(2, 10, 20, labels = c("Ctl","Trt"))
weight <- c(ctl, trt)
lm.D9 <- lm(weight ~ group)
output <- util.html_table(lm.D9)
```

```
output <- util.html_table(mtcars[1:3, c("cyl", "mpg")], print.results = FALSE)
```

In each case, and also _without_ the print.results option, it seemed to work correctly.