### PR TITLE
warning for util.find_crypt_paths

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -614,7 +614,7 @@ util.find_crypt_paths <- function (files_to_load, initial_path = NA,
         stop("in util.find_crypt_paths, files_to_load must be a list.")
     }
     
-    if(any(util.is_blank(names(files_to_load)))){
+    if(any(util.is_blank(names(files_to_load))) | is.null(names(files_to_load))){
         stop("in util.find_crypt_paths, all elements of the list files_to_load must be named (e.g., list(a = 'a',), not list('a')")
     }
 

--- a/R/util.R
+++ b/R/util.R
@@ -608,6 +608,15 @@ util.find_crypt_paths <- function (files_to_load, initial_path = NA,
     #     files. Zero means enter no subfolders.
     #
     # Returns: List with provided labels to absolute file paths.
+    
+    # check the format of files_to_load
+    if(!is.list(files_to_load)){
+        stop("in util.find_crypt_paths, files_to_load must be a list.")
+    }
+    
+    if(any(util.is_blank(names(files_to_load)))){
+        stop("in util.find_crypt_paths, all elements of the list files_to_load must be named (e.g., list(a = 'a',), not list('a')")
+    }
 
     if (.Platform$OS.type == 'unix') {
         # You may want to set this to '/media' if you're using linux.


### PR DESCRIPTION
This is literally the tiniest change you ever saw. I got tired of forgetting that the input to `util.find_crypt_paths()` has to be a named list, and can't be a vector or unnamed list. So I wrote an error to catch both of these things so that I don't have to trouble-shoot them over and over again.

(lmk if this is too minor a change to need a pull request. For gymnast, I err on the side of review because so many people use it)