### PR TITLE
fixed buggy indexing

### DIFF
--- a/R/util_dfc.R
+++ b/R/util_dfc.R
@@ -92,8 +92,8 @@ dfc.compare_df_values <- function(df1, df2, id_col, verbose = FALSE) {
   ##### ALL CHECKS PASSED - BEGIN VALUE-BY-VALUE COMPARISON #####
 
   # Cast NAs to the string "___NA___" so that "___NA___" == "___NA___" returns TRUE for all comparisons.
-  df1[is.na(df1)] <- "___NA___"
-  df2[is.na(df2)] <- "___NA___"
+  df1 <- util.apply_columns(df1, function(x) ifelse(is.na(x), "___NA___", x))
+  df2.1 <- util.apply_columns(df2, function(x) ifelse(is.na(x), "___NA___", x))
 
   # Compare DF values
   dfdiff <- as.data.frame(df1 == df2)


### PR DESCRIPTION
Problem: I got an error with dfc.compare_values that stemmed from this operation:
```
df1[is.na(df1)] <- "___NA___"
```

Turns out indexing data.frames in this way sometimes breaks. I never do it this way because I don't consider it robust. Using util.apply_columns is slower, but it doesn’t break.