### PR TITLE
Util to df fix

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -187,6 +187,7 @@ util.as_numeric_if_number <- function(x){
 to_type_tbldf_test <- function(){
     test_df <- data.frame(a = c(1, 2), b = c('c','d'))
     test_tbldf <- test_df %>% group_by(a)
+    test_vec <- c(1, 2)
     
     assert <- stopifnot
 
@@ -194,12 +195,15 @@ to_type_tbldf_test <- function(){
     # for both dfs and tbl_df types (i.e., data.frame-like objects returned by dplyr operations)
     assert(identical(dim(test_df), dim(util.to_character(test_df))))
     assert(identical(dim(test_tbldf), dim(util.to_character(test_tbldf))))
+    assert(identical(length(test_vec), length(util.to_character(test_vec))))
     
     assert(identical(dim(test_df), dim(util.to_ascii(test_df))))
     assert(identical(dim(test_tbldf), dim(util.to_ascii(test_tbldf))))
+    assert(identical(length(test_vec), length(util.to_ascii(test_vec))))
     
     assert(identical(dim(test_df), dim(util.as_numeric_if_number(test_df))))
     assert(identical(dim(test_tbldf), dim(util.as_numeric_if_number(test_tbldf))))
+    assert(identical(length(test_vec), length(util.as_numeric_if_number(test_vec))))
 }
 
 to_type_tbldf_test()

--- a/R/util.R
+++ b/R/util.R
@@ -202,7 +202,7 @@ to_type_tbldf_test <- function(){
     assert(identical(dim(test_tbldf), dim(util.as_numeric_if_number(test_tbldf))))
 }
 
-
+to_type_tbldf_test()
 ###############################################################
 ###
 ###     Messages

--- a/R/util.R
+++ b/R/util.R
@@ -184,6 +184,24 @@ util.as_numeric_if_number <- function(x){
     return(x)
 }
 
+to_type_tbldf_test <- function(){
+    test_df <- data.frame(a = c(1, 2), b = c('c','d'))
+    test_tbldf <- test_df %>% group_by(a)
+    
+    assert <- stopifnot
+
+    # all the util.to_ functions should return dfs of the same dimensions as the originals,
+    # for both dfs and tbl_df types (i.e., data.frame-like objects returned by dplyr operations)
+    assert(identical(dim(test_df), dim(util.to_character(test_df))))
+    assert(identical(dim(test_tbldf), dim(util.to_character(test_tbldf))))
+    
+    assert(identical(dim(test_df), dim(util.to_ascii(test_df))))
+    assert(identical(dim(test_tbldf), dim(util.to_ascii(test_tbldf))))
+    
+    assert(identical(dim(test_df), dim(util.as_numeric_if_number(test_df))))
+    assert(identical(dim(test_tbldf), dim(util.as_numeric_if_number(test_tbldf))))
+}
+
 
 ###############################################################
 ###

--- a/R/util.R
+++ b/R/util.R
@@ -111,7 +111,7 @@ util.is_blank <- function(x){
 util.to_character <- function(x){
     # like base::as.character()
     # but accepts (and returns) data frames or vectors
-    if(class(x) %in% "data.frame"){
+    if("data.frame" %in% class(x)){
         util.apply_columns(x, as.character)
     }
     else{ as.character(x) }
@@ -119,7 +119,7 @@ util.to_character <- function(x){
 
 
 util.to_ascii <- function(x){
-    if(class(x) %in% "data.frame"){
+    if("data.frame" %in% class(x)){
         util.apply_columns(x, util.strip_non_ascii)
     }
     else{util.strip_non_ascii(x) }
@@ -175,7 +175,7 @@ util.is_vector_of_numbers_test()
 util.as_numeric_if_number <- function(x){
     # run as.numeric if the x is made up of numbers
     # runs independently on each column if x is data.frame
-    if(class(x) %in% "data.frame"){
+    if("data.frame" %in% class(x)){
         return(util.apply_columns(x, util.as_numeric_if_number))
     }
     if(util.is_vector_of_numbers(x)){
@@ -328,7 +328,7 @@ util.html_table <- function(x, ...) {
 
 util.z_score <- function(x){
     # calculate the z-score of vector or for each vector in a data.frame
-    if(class(x) %in% "data.frame"){
+    if("data.frame" %in% class(x)){
         util.apply_columns(x,util.z_score)
     }
     else{ ( x - mean(x,na.rm=T) ) / sd(x,na.rm=T) }

--- a/R/util_dfc.R
+++ b/R/util_dfc.R
@@ -35,7 +35,7 @@ dfc.get_concatenated_ids <- function(df, id_cols) {
   # Helper function for getting a vector of IDs (not necessarily unique) from a DF.
   # If there are multiple ID columns, they need to be concatenated with "___".
   if(length(id_cols) == 1) {
-    return(as.character(df[, id_cols]))
+    return(as.character(df[[id_cols]]))
   } else {
     # use util.to_character do avoid some nasty behavior with apply(), which 
     # converts numeric types to varchars when passing to paste, so that white spaces 


### PR DESCRIPTION
This is a quick repair to a couple of the util functions, which I discover sometimes break when used with dplyr tbl_df objects. The problem is that tbl_df objects have more than one class attribute, which causes the following expression used by a number of our util functions to break:

`if(class(df) %in% "data.frame")`

The reason it breaks is because if `df` is a `tbl_df` object, it has multiple class attributes, e.g., 

```
class(test_tbldf)
[1] "grouped_df" "tbl_df"     "tbl"        "data.frame"
```

I fixed this by simply reversing the order of the two arguments on either side of `%in%`, i.e. `if("data.frame" %in% class(df)`, which returns TRUE if any class attributes of df are "data.frame".

I tested it quickly with the function `to_type_tbldf_test`.