### PR TITLE
Dfc add side by side

### DIFF
--- a/R/util_dfc.R
+++ b/R/util_dfc.R
@@ -123,7 +123,7 @@ dfc.compare_df_values <- function(df1, df2, id_col, verbose = FALSE) {
   unmatched_summary <- dfdiff_sum_cols[dfdiff_sum_cols$num_unmatched > 0, ]
   unmatched_cols <- unmatched_summary$variable_name
   
-  if(length(unmatched_cols) == 0){
+  if(length(unmatched_cols) > 0){
     side_by_side_df <- data.frame(matrix(nrow = nrow(dfdiff_sum_rows), ncol = 0))
     # we know they're all sorted the same way, so we can build the data.frame just by concatenating columns
     side_by_side_df[[id_col]] <- dfdiff_sum_rows[[id_col]]
@@ -272,6 +272,10 @@ dfc.get_granular_mismatches <- function(values_comparison, id_cols = "index"){
   var_names <- expand.grid(vars, suffixes) %>%
     setNames(c("variable", "suffix")) %>%
     mutate(colname = variable %+% suffix)
+  
+  # restrict to rows with at least one mismatch (to save computation time)
+  sbs_df$at_least_one_mismatch <- values_comparison$row_summary$num_unmatched > 0
+  sbs_df <- sbs_df[sbs_df$at_least_one_mismatch, ]
   
   # to look at granular mismatches, restrict to columns with unmatched values,
   # handle duplicate indices by marking each instance

--- a/R/util_dfc.R
+++ b/R/util_dfc.R
@@ -118,13 +118,29 @@ dfc.compare_df_values <- function(df1, df2, id_col, verbose = FALSE) {
   # need to attach the original ids too.
   dfdiff_sum_rows[, id_col] <- df1[, id_col]
   dfdiff_sum_rows <- dfdiff_sum_rows[, c(id_col, "pct_unmatched", "num_unmatched")]
-
+  
+  # get a side-by-side comparison of any unmatched values
+  unmatched_summary <- dfdiff_sum_cols[dfdiff_sum_cols$num_unmatched > 0, ]
+  unmatched_cols <- unmatched_summary$variable_name
+  
+  if(length(unmatched_cols) > 0){
+    side_by_side_df <- data.frame(matrix(nrow = nrow(dfdiff_sum_rows), ncol = 0))
+    # we know they're all sorted the same way, so we can build the data.frame just by concatenating columns
+    side_by_side_df[[id_col]] <- dfdiff_sum_rows[[id_col]]
+    for(col in unmatched_cols){
+      side_by_side_df[[col %+% "_matches"]] <- diff_df[[col]]
+      side_by_side_df[[col %+% "_df1"]] <- df1[[col]]
+      side_by_side_df[[col %+% "_df2"]] <- df2[[col]]
+    }
+  }
+  
   if(verbose) {util.html_table(head(dfdiff_sum_rows))}
 
   # Return diff DF and full summary dfs for user.
   return(list(diff_df = dfdiff,
               row_summary = dfdiff_sum_rows,
-              col_summary = dfdiff_sum_cols))
+              col_summary = dfdiff_sum_cols,
+              side_by_side_df = side_by_side_df))
 
 }
 

--- a/R/util_dfc.R
+++ b/R/util_dfc.R
@@ -128,7 +128,7 @@ dfc.compare_df_values <- function(df1, df2, id_col, verbose = FALSE) {
     # we know they're all sorted the same way, so we can build the data.frame just by concatenating columns
     side_by_side_df[[id_col]] <- dfdiff_sum_rows[[id_col]]
     for(col in unmatched_cols){
-      side_by_side_df[[col %+% "_matches"]] <- diff_df[[col]]
+      side_by_side_df[[col %+% "_matches"]] <- dfdiff[[col]]
       side_by_side_df[[col %+% "_df1"]] <- df1[[col]]
       side_by_side_df[[col %+% "_df2"]] <- df2[[col]]
     }

--- a/R/util_dfc.R
+++ b/R/util_dfc.R
@@ -123,7 +123,7 @@ dfc.compare_df_values <- function(df1, df2, id_col, verbose = FALSE) {
   unmatched_summary <- dfdiff_sum_cols[dfdiff_sum_cols$num_unmatched > 0, ]
   unmatched_cols <- unmatched_summary$variable_name
   
-  if(length(unmatched_cols) > 0){
+  if(length(unmatched_cols) == 0){
     side_by_side_df <- data.frame(matrix(nrow = nrow(dfdiff_sum_rows), ncol = 0))
     # we know they're all sorted the same way, so we can build the data.frame just by concatenating columns
     side_by_side_df[[id_col]] <- dfdiff_sum_rows[[id_col]]
@@ -132,6 +132,8 @@ dfc.compare_df_values <- function(df1, df2, id_col, verbose = FALSE) {
       side_by_side_df[[col %+% "_df1"]] <- df1[[col]]
       side_by_side_df[[col %+% "_df2"]] <- df2[[col]]
     }
+  } else{
+    side_by_side_df <- NA
   }
   
   if(verbose) {util.html_table(head(dfdiff_sum_rows))}


### PR DESCRIPTION
# Overview

I'm submitting the supplementary functions I used to employ `util.dfc` into the IES data pipeline. Functions do the following:

* Function to clean meaningless differences before comparison (e.g., blanks, rounding errors, special characters)
* Wrapper function to run index, column, and values comparison and return a "comparison" object used by other functions
* Addition to `dfc.compare_df_values` to return a side-by-side comparison of values for non-matching columns (in addition to the `dfdiff`)
* Wrapper function to make a quick summary in data.frame form of results of comparison operations
* Function to return a summary of all differing values, in easy format to summarize with dplyr functions

# Testing/Feedback
The only testing I've done is to use the functions in my own pipeline analysis. Until we have time for more systematic testing, these functions will remain in this branch. The next person/people to use them ought to review the functions, see if they duplicate other efforts out there (i.e., if there are R packages that accomplish this same purpose), and if they don't, think about how the functions are organized, what revisions should be made, and what testing ought to be done.