### PR TITLE
function to enumerate duplicates

### DIFF
--- a/R/util_qualtrics_cleaning.R
+++ b/R/util_qualtrics_cleaning.R
@@ -110,6 +110,8 @@ qc.test_enumerate_duplicates <- function(){
   )
 }
 
+qc.test_enumerate_duplicates()
+
 qc.extract_delimited <- function(x,delimiter = "__pdd__"){
     # Input:
     # - string vector from first row of raw Qualtrics dataset containing second


### PR DESCRIPTION
## Overview

This is a function to do something we talked about a long time ago, which is to add numeric suffixes to differentiate columns duplicated during the qc.clean_qualtrics process (usually engendered by the pdd tags). E.g., if a checkbox type question has a pdd tag, the columns will be renamed such that _all_ columns associated with that question have the same column label. This mucks things up down the line because even if you want to fix the duplicates manually, a lot of functions throw errors when given data frames with non-unique column names.

## Implementation
This function assigns a numeric suffix to columns labeled the same way, e.g., if the column names are "col1", "col2", "col1", "col2", they now will be "col1.1", "col2.1", "col1.2", "col2.2". (Note that the dot-suffix parallels R's default behavior when reading in new .csv files in which column names are duplicated.)

## Testing
I did a bare-bones unit-test called `qc.test_enumerate_duplicates`.

## Consequences
This fix may break or change the results of any manual fixes that have been used in the past. I've made it so that a warning is thrown when duplicates are automatically enumerated, so hopefully this will tip the user off when enumeration has happened and make it easy to trace any ensuing problems to this change. There is minor danger that the change could affect some old CTC scripts (e.g., the CTC full datasets script). However, I think it's worth the risk because (a) this is a million times better; (b) hopefully we didn't do something janky with CTC like create a bunch of duplicated column names and then fix them manually; and (c) it would likely be easy to trouble-shoot because the new duplicate-handling procedure throws an informative warning.

## Question
Should this maybe be a `util` function instead of a `qc` function? It could just be `util.enumerate_duplicates <- function(x)` instead of tying its meaning to column names. I feel like there could be more use cases for it...