### PR TITLE
add ensure_packages, use in gymnast_install()

### DIFF
--- a/R/ensure_packages.R
+++ b/R/ensure_packages.R
@@ -1,0 +1,29 @@
+ensure_packages <- function (libs, prefer_type = "binary") {
+  # Install `libs` if they aren't installed already.
+  #
+  # Args:
+  #   libs - character, packages to maybe install
+  #   prefer_type - character, default "binary", or "source", sets
+  #     options(install.packages.check.source) which is an indirect way of
+  #     controlling whether we use binary or source installation, since the
+  #     `type` argument of install.packages() is platform-dependent and thus
+  #     unreliable.
+  if (prefer_type == "binary") {
+    # Prefer binary packages, even if the source version is farther ahead.
+    # This is default because it's so much faster to install a binary.
+    options(install.packages.check.source = "no")
+  } else if (prefer_type == "source") {
+    options(install.packages.check.source = NULL)
+  }
+
+  installed <- utils::installed.packages()[,"Package"]
+  to_install <- libs[!(libs %in% installed)]
+
+  if (length(to_install)) {
+    utils::install.packages(
+      to_install,
+      repos = 'http://cran.us.r-project.org'
+      # type = 'binary'  # doesn't work for some platforms, e.g. linux
+    )
+  }
+}

--- a/R/util.R
+++ b/R/util.R
@@ -712,6 +712,8 @@ util.find_crypt_paths <- function (files_to_load, initial_path = NA,
 ###
 ###############################################################
 
+source('ensure_packages.R')
+
 gymnast_install <- function () {
     # Load (or install) all packages used by gymnast.
     dependencies <- c(
@@ -720,14 +722,11 @@ gymnast_install <- function () {
         "lmerTest","psych","reshape2","scales" ,
         "stargazer","stringr","xtable"
     )
+
+    ensure_packages(dependencies, prefer_type = "source")
+
     for(lib_name in dependencies){
-        message(paste0("Loading... ",lib_name))
-        # Require returns FALSE if packages failed
-        if( !require(lib_name, character.only = TRUE) ){
-            install.packages(lib_name)
-            # library raises error if installation failed
-            library(lib_name, character.only = TRUE)
-        }
+        library(lib_name, character.only = TRUE)
     }
     # Do not uncomment without resolving issue #27!
     # resolve_name_conflicts()


### PR DESCRIPTION
I made the function `ensure_packages` to address the problem of making sure certain packages were available, regardless of your R installation (including RServe's environment). But it's hard to use because I can't reliably _find_ that function, i.e. `source('common/ensure_packages.R')` only works if the working directory has a certain value. I can set it up to work from inside RServe, but then other analysis code doesn't work.

My new plan is to refer to this with a raw github URL, which is absolute and works regardless of the working directory:

```
source(
  "https://raw.githubusercontent.com/PERTS/gymnast/master/R/ensure_packages.R",
  local = environment()
)
```

This is the way we use gymnast already, it's just pulling a single function instead of all of `util`.

## Testing

I pulled gymnast's `util.R` from a raw github link with this change, and the `gymnast_install` function operated without complaint, because I had all the packages already. I uninstalled a package and did the same, and it installed it back for me. All packages were in my local environment via the `library()` calls, e.g. `summarise` at the command line showed the function.

It also allows common scripts like big pipe to work from other working directories, i.e. it solves the original problem:

```
setwd('~/Sites/analysis')
source('common/big_pipe.R')  # this uses ensure_packages()
# no error
```