### PR TITLE
46 empty tables

### DIFF
--- a/R/json_utils.R
+++ b/R/json_utils.R
@@ -52,7 +52,7 @@ parse_numeric_array <- function (json_array) {
   return(as.numeric(result))
 }
 
-expand_vector_column_ <- function (df, column_name) {
+expand_vector_column_ <- function (df, column_name, as_type = NULL) {
   # Take a data frame that has a column where the elements have length > 1
   # and multiply the rows for each element in the vector.
   #
@@ -72,6 +72,10 @@ expand_vector_column_ <- function (df, column_name) {
   # 5 3 by
 
   if (nrow(df) == 0) {
+    if (!is.null(as_type)) {
+      df[[column_name]] <- as_type(df[[column_name]])
+    }
+
     return(df)
   }
 
@@ -116,6 +120,10 @@ expand_vector_column_ <- function (df, column_name) {
     bound <- do.call(rbind, dfs_to_bind)
   }
 
+  if (!is.null(as_type)) {
+    bound[[column_name]] <- as_type(bound[[column_name]])
+  }
+
   return(tibble::as.tibble(bound))
 }
 
@@ -140,7 +148,7 @@ expand_string_array_column <- function (df, column_name) {
   # tidy once again. Make sure to convert the nse argument
   # (an "expression") into a string for easier processing
   # downstream.
-  return(expand_vector_column_(parsed_df, deparse(col_expr)))
+  return(expand_vector_column_(parsed_df, deparse(col_expr), as.character))
 }
 
 expand_numeric_array_column <- function (df, column_name) {
@@ -157,7 +165,7 @@ expand_numeric_array_column <- function (df, column_name) {
   # tidy once again. Make sure to convert the nse argument
   # (an "expression") into a string for easier processing
   # downstream.
-  return(expand_vector_column_(parsed_df, deparse(col_expr)))
+  return(expand_vector_column_(parsed_df, deparse(col_expr), as.numeric))
 }
 
 widen_object_column <- function(df, column_name) {

--- a/R/summarize_copilot.R
+++ b/R/summarize_copilot.R
@@ -524,6 +524,16 @@ get_classrooms_from_organization <- function(organization_ids,
                                              triton.classroom,
                                              triton.team,
                                              triton.organization) {
+  platform_tables <- list(triton.classroom, triton.team, triton.organization)
+  for (table in platform_tables) {
+    if (nrow(table) == 0) {
+      warning(
+        "summarize_copilot$get_classrooms_from_organization() received " %+%
+        "a platform table with zero rows."
+      )
+    }
+  }
+
   team_org_assoc <- triton.team %>%
     json_utils$expand_string_array_column(team.organization_ids) %>%
     rename(organization.uid = "team.organization_ids") %>%
@@ -557,6 +567,21 @@ get_classrooms_from_network <- function (network_ids,
                                          triton.team,
                                          triton.organization,
                                          triton.network) {
+  platform_tables <- list(
+    triton.classroom,
+    triton.team,
+    triton.organization,
+    triton.network
+  )
+  for (table in platform_tables) {
+    if (nrow(table) == 0) {
+      warning(
+        "summarize_copilot$get_classrooms_from_organization() received " %+%
+        "a platform table with zero rows."
+      )
+    }
+  }
+
   # Long form relationship table, unique by network-child
   network_assc <- triton.network %>%
     filter(network.uid %in% network_ids) %>%

--- a/tests/testthat/test_json_utils.R
+++ b/tests/testthat/test_json_utils.R
@@ -190,6 +190,16 @@ describe("expand_string_array_column", {
 
     expect_equal(actual, expected)
   })
+
+  it("has correct type when df has zero rows", {
+    df <- dplyr::tibble(a = character(), j = character())
+
+    actual <- json_utils$expand_string_array_column(df, j)
+
+    expected <- dplyr::tibble(a = character(), j = character())
+
+    expect_equal(actual, expected)
+  })
 })
 
 describe("expand_numeric_array_column", {
@@ -209,6 +219,16 @@ describe("expand_numeric_array_column", {
       a = c(1, 1, 1,  2,    3,    3),
       j = c(4, 5, 6, NA, 10.1, -5e5)
     )
+
+    expect_equal(actual, expected)
+  })
+
+  it("has correct type when df has zero rows", {
+    df <- dplyr::tibble(a = character(), j = character())
+
+    actual <- json_utils$expand_numeric_array_column(df, j)
+
+    expected <- dplyr::tibble(a = character(), j = numeric())
 
     expect_equal(actual, expected)
   })

--- a/tests/testthat/test_summarize_copilot.R
+++ b/tests/testthat/test_summarize_copilot.R
@@ -18,14 +18,14 @@ if (grepl("tests/testthat$", getwd())) {
 
 library(testthat)
 
-modules::import("dplyr", `%>%`, 'tribble')
+modules::import("dplyr", `%>%`, 'filter', 'tibble', 'tribble')
 
 summarize_copilot <- import_module("summarize_copilot")
 sql <- import_module("sql")
 
 tables <- sql$prefix_tables(list(
   classroom = tribble(
-    ~uid,          ~name,     ~team_id, ~code,      
+    ~uid,          ~name,     ~team_id, ~code,
     'Classroom_A', 'Class A', 'Team_A', 'alpha fox',
     'Classroom_B', 'Class B', 'Team_B', 'beta fox',
     'Classroom_C', 'Class C', 'Team_C', 'charlie fox'
@@ -75,6 +75,61 @@ describe('get_classrooms_from_organization', {
     expected = cbind(expected1, expected2)
 
     expect_equal(child_assc, expected)
+  })
+
+  it('returns zero rows if no ru ids found', {
+    child_assc <- summarize_copilot$get_classrooms_from_organization(
+      c('Organization_DNE', 'Team_ignored'),
+      tables$classroom,
+      tables$team,
+      tables$organization
+    )
+
+    expected <- tibble(
+      parent_id = character(),
+      parent_name = character(),
+      child_id = character(),
+      child_name = character(),
+      team.uid = character(),
+      team.name = character(),
+      classroom.uid = character(),
+      classroom.code = character()
+    )
+
+    expect_equal(child_assc, expected)
+  })
+
+  it('warns if classroom table is empty', {
+    expect_warning(
+      summarize_copilot$get_classrooms_from_organization(
+        character(),
+        filter(tables$classroom, classroom.uid %in% 'does not exist'),
+        tables$team,
+        tables$organization
+      )
+    )
+  })
+
+  it('warns if team table is empty', {
+    expect_warning(
+      summarize_copilot$get_classrooms_from_organization(
+        character(),
+        tables$classroom,
+        filter(tables$team, team.uid %in% 'does not exist'),
+        tables$organization
+      )
+    )
+  })
+
+  it('warns if organization table is empty', {
+    expect_warning(
+      summarize_copilot$get_classrooms_from_organization(
+        character(),
+        tables$classroom,
+        tables$team,
+        filter(tables$organization, organization.uid %in% 'does not exist')
+      )
+    )
   })
 })
 
@@ -130,5 +185,77 @@ describe('get_classrooms_from_network', {
     expected = cbind(expected1, expected2)
 
     expect_equal(classroom_assc, expected)
+  })
+
+
+  it('returns zero rows if no ru ids found', {
+    child_assc <- summarize_copilot$get_classrooms_from_network(
+      c('Network_DNE', 'Team_ignored'),
+      tables$classroom,
+      tables$team,
+      tables$organization,
+      tables$network
+    )
+
+    expected <- tibble(
+      parent_id = character(),
+      parent_name = character(),
+      child_id = character(),
+      child_name = character(),
+      team.uid = character(),
+      team.name = character(),
+      classroom.uid = character(),
+      classroom.code = character()
+    )
+
+    expect_equal(child_assc, expected)
+  })
+
+  it('warns if classroom table is empty', {
+    expect_warning(
+      summarize_copilot$get_classrooms_from_network(
+        character(),
+        filter(tables$classroom, classroom.uid %in% 'does not exist'),
+        tables$team,
+        tables$organization,
+        tables$network
+      )
+    )
+  })
+
+  it('warns if team table is empty', {
+    expect_warning(
+      summarize_copilot$get_classrooms_from_network(
+        character(),
+        tables$classroom,
+        filter(tables$team, team.uid %in% 'does not exist'),
+        tables$organization,
+        tables$network
+      )
+    )
+  })
+
+  it('warns if organization table is empty', {
+    expect_warning(
+      summarize_copilot$get_classrooms_from_network(
+        character(),
+        tables$classroom,
+        tables$team,
+        filter(tables$organization, organization.uid %in% 'does not exist'),
+        tables$network
+      )
+    )
+  })
+
+  it('warns if network table is empty', {
+    expect_warning(
+      summarize_copilot$get_classrooms_from_network(
+        character(),
+        tables$classroom,
+        tables$team,
+        tables$organization,
+        filter(tables$network, network.uid %in% 'does not exist')
+      )
+    )
   })
 })


### PR DESCRIPTION
Closes #46 

We found that empty platform tables (like an empty `network` table) in rserve e2e tests was causing a confusing error. This should fix it up.

* I corrected the column vector types for empty dfs so we won't get obscure errors any more
* I added tests that include empty tables as inputs. They don't throw errors but they _do_ send warnings, since this is almost never what we want.
* I made sure that the functions return a 0-row association table when none of the requested ids match up, so we don't have to handle any special cases in the metascript.