### PR TITLE
Break up join fns

### DIFF
--- a/R/summarize_copilot.R
+++ b/R/summarize_copilot.R
@@ -552,6 +552,14 @@ get_classrooms_from_organization <- function(organization_ids,
         "a platform table with zero rows."
       )
     }
+    for (col in names(table)) {
+      if (!grepl('\\.', col)) {
+        stop(
+          "summarize_copilot$get_classrooms_from_organization() received " %+%
+          "unprefixed column names."
+        )
+      }
+    }
   }
 
   team_org_assoc <- triton.team %>%
@@ -596,9 +604,17 @@ get_classrooms_from_network <- function (network_ids,
   for (table in platform_tables) {
     if (nrow(table) == 0) {
       warning(
-        "summarize_copilot$get_classrooms_from_organization() received " %+%
+        "summarize_copilot$get_classrooms_from_network() received " %+%
         "a platform table with zero rows."
       )
+    }
+    for (col in names(table)) {
+      if (!grepl('\\.', col)) {
+        stop(
+          "summarize_copilot$get_classrooms_from_network() received " %+%
+          "unprefixed column names."
+        )
+      }
     }
   }
 

--- a/R/summarize_copilot.R
+++ b/R/summarize_copilot.R
@@ -167,6 +167,15 @@ team_cycle_class_participation <- function(tcc,
   return(tcc_ppn)
 }
 
+team_user <- function (triton.team, triton.user) {
+  # Represents team membership, or users who either created or been invited to
+  # a team.
+  triton.user %>%
+    json_utils$expand_string_array_column(user.owned_teams) %>%
+    rename(team.uid = user.owned_teams) %>%
+    right_join(triton.team, by = 'team.uid')
+}
+
 team_organization <- function(triton.team, triton.organization) {
   triton.team %>%
     json_utils$expand_string_array_column(team.organization_ids) %>%
@@ -176,11 +185,11 @@ team_organization <- function(triton.team, triton.organization) {
 }
 
 organization_user <- function(triton.organization, triton.user) {
+  # Represents org/community membership, i.e. community admins.
   triton.user %>%
     json_utils$expand_string_array_column(user.owned_organizations) %>%
     rename(organization.uid = user.owned_organizations) %>%
     right_join(triton.organization, by = 'organization.uid')
-
 }
 
 team_organization_user <- function(triton.team,

--- a/R/summarize_copilot.R
+++ b/R/summarize_copilot.R
@@ -12,6 +12,7 @@ modules::import(
   "n",
   "pull",
   "rename",
+  "right_join",
   "select",
   "summarise",
   "tibble"
@@ -166,6 +167,38 @@ team_cycle_class_participation <- function(tcc,
   return(tcc_ppn)
 }
 
+team_organization <- function(triton.team, triton.organization) {
+  triton.team %>%
+    json_utils$expand_string_array_column(team.organization_ids) %>%
+    rename(organization.uid = "team.organization_ids") %>%
+    # team-org level
+    left_join(triton.organization, by = 'organization.uid')
+}
+
+organization_user <- function(triton.organization, triton.user) {
+  triton.user %>%
+    json_utils$expand_string_array_column(user.owned_organizations) %>%
+    rename(organization.uid = user.owned_organizations) %>%
+    right_join(triton.organization, by = 'organization.uid')
+
+}
+
+team_organization_user <- function(triton.team,
+                                   triton.organization,
+                                   triton.user) {
+  admin_assc <- organization_user(
+    triton.organization %>% select(organization.uid),
+    triton.user
+  ) %>%
+    # Drop users who aren't admin on any organizations, otherwise users
+    # associated with org "NA" will get joined to teams associated with org "NA"
+    # which is wrong.
+    filter(!is.na(user.uid))
+
+  team_organization(triton.team, triton.organization) %>%
+    left_join(admin_assc, by = 'organization.uid')
+}
+
 team_community_names <- function(triton.team,
                                  triton.organization,
                                  triton.user) {
@@ -175,19 +208,13 @@ team_community_names <- function(triton.team,
   # * community_names
   # * community_admin_names
   # * community_admin_emails
-  user_org_assc <- triton.user %>%
-    json_utils$expand_string_array_column(user.owned_organizations) %>%
-    # Drop users who aren't admin on any organizations, otherwise users
-    # associated with org "NA" will get joined to teams associated with org "NA"
-    # which is wrong.
-    filter(!is.na(user.owned_organizations)) %>%
-    rename(organization.uid = user.owned_organizations)
+  tou <- team_organization_user(
+    triton.team,
+    triton.organization,
+    triton.user
+  )
 
-  team_org_assoc <- triton.team %>%
-    json_utils$expand_string_array_column(team.organization_ids) %>%
-    rename(organization.uid = "team.organization_ids")
-
-  if (all(is.na(team_org_assoc$organization.uid))) {
+  if (all(is.na(tou$organization.uid))) {
     # There are no communities to process. Add the expected columns as NA.
     return(triton.team %>%
       select(team.uid) %>%
@@ -199,14 +226,7 @@ team_community_names <- function(triton.team,
     )
   }
 
-  team_org_assoc %>%
-    # team-org level
-    left_join(
-      triton.organization,
-      by = c("organization.uid")
-    ) %>%
-    # team-org-user level
-    left_join(user_org_assc, by = "organization.uid") %>%
+  tou %>%
     group_by(team.uid) %>%
     summarise(
       community_names = paste(

--- a/tests/testthat/test_summarize_copilot.R
+++ b/tests/testthat/test_summarize_copilot.R
@@ -212,7 +212,7 @@ describe('get_classrooms_from_organization', {
     expect_warning(
       summarize_copilot$get_classrooms_from_organization(
         character(),
-        filter(tables$classroom, classroom.uid %in% 'does not exist'),
+        tables$classroom[integer(), ],
         tables$team,
         tables$organization
       )
@@ -224,7 +224,7 @@ describe('get_classrooms_from_organization', {
       summarize_copilot$get_classrooms_from_organization(
         character(),
         tables$classroom,
-        filter(tables$team, team.uid %in% 'does not exist'),
+        tables$team[integer(), ],
         tables$organization
       )
     )
@@ -236,7 +236,7 @@ describe('get_classrooms_from_organization', {
         character(),
         tables$classroom,
         tables$team,
-        filter(tables$organization, organization.uid %in% 'does not exist')
+        tables$organization[integer(), ]
       )
     )
   })
@@ -335,7 +335,7 @@ describe('get_classrooms_from_network', {
     expect_warning(
       summarize_copilot$get_classrooms_from_network(
         character(),
-        filter(tables$classroom, classroom.uid %in% 'does not exist'),
+        tables$classroom[integer(), ],
         tables$team,
         tables$organization,
         tables$network
@@ -348,7 +348,7 @@ describe('get_classrooms_from_network', {
       summarize_copilot$get_classrooms_from_network(
         character(),
         tables$classroom,
-        filter(tables$team, team.uid %in% 'does not exist'),
+        tables$team[integer(), ],
         tables$organization,
         tables$network
       )
@@ -361,7 +361,7 @@ describe('get_classrooms_from_network', {
         character(),
         tables$classroom,
         tables$team,
-        filter(tables$organization, organization.uid %in% 'does not exist'),
+        tables$organization[integer(), ],
         tables$network
       )
     )
@@ -374,7 +374,7 @@ describe('get_classrooms_from_network', {
         tables$classroom,
         tables$team,
         tables$organization,
-        filter(tables$network, network.uid %in% 'does not exist')
+        tables$network[integer(), ]
       )
     )
   })

--- a/tests/testthat/test_summarize_copilot.R
+++ b/tests/testthat/test_summarize_copilot.R
@@ -18,7 +18,15 @@ if (grepl("tests/testthat$", getwd())) {
 
 library(testthat)
 
-modules::import("dplyr", `%>%`, 'filter', 'select', 'tibble', 'tribble')
+modules::import(
+  'dplyr',
+  `%>%`,
+  'filter',
+  'rename',
+  'select',
+  'tibble',
+  'tribble'
+)
 
 summarize_copilot <- import_module("summarize_copilot")
 sql <- import_module("sql")
@@ -232,6 +240,17 @@ describe('get_classrooms_from_organization', {
       )
     )
   })
+
+  it('stops if tables don\'t have prefixed column names', {
+    expect_error(
+      summarize_copilot$get_classrooms_from_organization(
+        character(),
+        tables$classroom %>% rename(uid = classroom.uid),
+        tables$team,
+        tables$organization,
+      )
+    )
+  })
 })
 
 describe('get_classrooms_from_network', {
@@ -356,6 +375,18 @@ describe('get_classrooms_from_network', {
         tables$team,
         tables$organization,
         filter(tables$network, network.uid %in% 'does not exist')
+      )
+    )
+  })
+
+  it('stops if tables don\'t have prefixed column names', {
+    expect_error(
+      summarize_copilot$get_classrooms_from_network(
+        character(),
+        tables$classroom,
+        tables$team,
+        tables$organization,
+        tables$network %>% rename(uid = network.uid)
       )
     )
   })

--- a/tests/testthat/test_summarize_copilot.R
+++ b/tests/testthat/test_summarize_copilot.R
@@ -70,6 +70,28 @@ tables <- sql$prefix_tables(list(
   )
 ))
 
+describe('team_user', {
+  it('default case', {
+    tu <- summarize_copilot$team_user(
+      tables$team,
+      tables$user
+    )
+
+    expected <- tribble(
+      ~team.uid, ~user.uid,
+      'Team_A',  'User_A',
+      'Team_B',  'User_A',
+      'Team_C',  NA,
+      'Team_D',  NA
+    )
+
+    expect_equal(
+      tu %>% select(team.uid, user.uid),
+      expected
+    )
+  })
+})
+
 describe('team_organization', {
   it('default case', {
     team_org <- summarize_copilot$team_organization(


### PR DESCRIPTION
## Background

We should centralize and re-use logic having to do with wrangling the Triton/Copilot schema in `summarize_copilot`. But that means the functions there need to be generic enough to use.

## Implementation

This puts each join operation of relating team, organization, and user into a separate function, while maintaining the functionality used for the dashboard in `team_community_names()`.

Notice that the function names represent left-to-right joins. So `organization_user` is what you would expect from just `merge(organization, user)` with all the complexities worked out.

## Testing

I wrote a "default case" test for each function. Not ever edge case I could think of is covered, e.g. multiple rows when a team is supervised by multiple org admins, but I was going for speed b/c SG is actively developing with this stuff.

## Misc

I also added that error SG suggested re: forgetting to prefix your tables.