### PR TITLE
2020 report fixes

### DIFF
--- a/R/summarize_copilot.R
+++ b/R/summarize_copilot.R
@@ -338,6 +338,11 @@ map_responses_to_cycles <- function(response_tbl,
   # * created_date
   # * cycle_ordinal
 
+  added_cols <- c('cycle_id', 'created_date', 'cycle_ordinal')
+  if (any(added_cols %in% names(response_tbl))) {
+    stop("map_responses_to_cycles would overwrite columns")
+  }
+
   missing_codes <- unique(
     response_tbl$code[!response_tbl$code %in% triton.classroom$classroom.code]
   )

--- a/tests/testthat/test_json_utils.R
+++ b/tests/testthat/test_json_utils.R
@@ -182,10 +182,9 @@ describe("expand_string_array_column", {
 
     actual <- json_utils$expand_string_array_column(df, j)
 
-    expected <- data.frame(
+    expected <- dplyr::tibble(
       a = c(    1,     1,     1,  2,    3,     3),
-      j = c("foo", "bar", "baz", NA, "hi", "bye"),
-      stringsAsFactors = FALSE
+      j = c("foo", "bar", "baz", NA, "hi", "bye")
     )
 
     expect_equal(actual, expected)

--- a/tests/testthat/test_summarize_copilot.R
+++ b/tests/testthat/test_summarize_copilot.R
@@ -21,6 +21,8 @@ library(testthat)
 modules::import(
   'dplyr',
   `%>%`,
+  'arrange',
+  'as_tibble',
   'filter',
   'rename',
   'select',
@@ -187,7 +189,7 @@ describe('get_classrooms_from_organization', {
       tables$classroom,
       tables$team,
       tables$organization
-    )
+    ) %>% arrange(parent_id, child_id)
 
     expected1 <- tribble(
       ~parent_id,        ~parent_name, ~child_id, ~child_name, ~team.uid,
@@ -203,7 +205,9 @@ describe('get_classrooms_from_organization', {
        'Team A',   'Classroom_A',  'alpha fox',
        'Team B',   'Classroom_B',  'beta fox'
     )
-    expected = cbind(expected1, expected2)
+    expected = cbind(expected1, expected2) %>%
+      as_tibble() %>%
+      arrange(parent_id, child_id)
 
     expect_equal(child_assc, expected)
   })
@@ -299,7 +303,7 @@ describe('get_classrooms_from_network', {
       'Team C',   'Classroom_C',  'charlie fox',
       'Team A',   'Classroom_A',  'alpha fox'
     )
-    expected = cbind(expected1, expected2)
+    expected = as_tibble(cbind(expected1, expected2))
 
     expect_equal(classroom_assc, expected)
   })
@@ -324,7 +328,7 @@ describe('get_classrooms_from_network', {
       'Team A',   'Classroom_A',  'alpha fox',
       'Team C',   'Classroom_C',  'charlie fox'
     )
-    expected = cbind(expected1, expected2)
+    expected = as_tibble(cbind(expected1, expected2))
 
     expect_equal(classroom_assc, expected)
   })

--- a/tests/testthat/test_summarize_copilot.R
+++ b/tests/testthat/test_summarize_copilot.R
@@ -32,6 +32,7 @@ modules::import(
 
 summarize_copilot <- import_module("summarize_copilot")
 sql <- import_module("sql")
+util <- import_module("util")
 
 tables <- sql$prefix_tables(list(
   user = cbind(
@@ -415,5 +416,45 @@ describe('get_classrooms_from_network', {
         tables$network %>% rename(uid = network.uid)
       )
     )
+  })
+})
+
+describe('map_responses_to_cycles', {
+  it('handles multiple team ids', {
+    response_tbl <- tribble(
+      ~participant_id, ~created,              ~code,
+      'Participant_1', '2020-01-01 12:00:00', 'trout viper', # Team Viper
+      'Participant_2', '2020-01-15 12:00:00', 'bass viper', # Team Viper
+      'Participant_3', '2020-01-01 12:00:00', 'fancy fox' # Team Fox
+    )
+
+    triton.cycle <- tribble(
+      ~uid,       ~team_id,     ~start_date,  ~end_date,    ~ordinal,
+      'Cycle_1',  'Team_Viper', '2020-01-01', '2020-01-14', 1,
+      'Cycle_2',  'Team_Viper', '2020-01-15', '2020-01-30', 2,
+      'Cycle_3',  'Team_Fox',   '2020-01-01', '2020-01-14', 1,
+      'Cycle_4',  'Team_Fox',   '2020-01-15', '2020-01-30', 2
+    ) %>% util$prefix_columns('cycle')
+
+    triton.classroom <- tribble(
+      ~team_id,     ~code,
+      'Team_Viper', 'trout viper',
+      'Team_Viper', 'bass viper',
+      'Team_Fox',   'fancy fox'
+    ) %>% util$prefix_columns('classroom')
+
+    actual <- summarize_copilot$map_responses_to_cycles(
+      response_tbl, triton.cycle, triton.classroom)
+
+    additional_columns <- tribble(
+      ~classroom.team_id, ~created_date, ~cycle_id, ~cycle_ordinal,
+      'Team_Viper',       '2020-01-01',  'Cycle_1', 1,
+      'Team_Viper',       '2020-01-15',  'Cycle_2', 2,
+      'Team_Fox',         '2020-01-01',  'Cycle_3', 1
+    )
+    expected <- cbind(response_tbl, additional_columns) %>%
+      as_tibble()
+
+    expect_equal(actual, expected)
   })
 })


### PR DESCRIPTION
## Background

We want to start using `summarize_copilot$map_responses_to_cycles` in RServe (and other places) but it currently only supports working on one team at a time.

## Implementation

I just had it check that the team id matches when it's checking if the dates match for a given cycle

```
    in_cycle <- (
      response_merged$created_date >= this_cycle$cycle.start_date &
        response_merged$created_date <= this_cycle$cycle.end_date &
        response_merged$classroom.team_id %in% this_cycle$cycle.team_id
    )
```

## Testing

Unit tests included.

## Feedback

As long as I had those tables nice and lined up, I included the `cycle_id` also, since that will allow arbitrary later joins to the cycle table. Sound good? I made sure to add some code that alerts us if adding these extra columns would cause any problems.