### PR TITLE
use extended end date in map_responses_to_cycles

### DIFF
--- a/R/summarize_copilot.R
+++ b/R/summarize_copilot.R
@@ -372,7 +372,7 @@ map_responses_to_cycles <- function(response_tbl,
     this_cycle <- triton.cycle[i, ]
     in_cycle <- (
       response_merged$created_date >= this_cycle$cycle.start_date &
-        response_merged$created_date <= this_cycle$cycle.end_date &
+        response_merged$created_date <= this_cycle$cycle.extended_end_date &
         response_merged$classroom.team_id %in% this_cycle$cycle.team_id
     )
     response_merged$cycle_id[in_cycle] <- this_cycle$cycle.uid


### PR DESCRIPTION
This was also causing reports to under-report participation when compared to copilot. The metascript was already doing this, but we switched to using my new function, which didn't have this schema update :-( :-(