### PR TITLE
Optimize summarize

### DIFF
--- a/R/summarize_copilot.R
+++ b/R/summarize_copilot.R
@@ -97,15 +97,22 @@ team_cycle_class <- function(team_class, triton.cycle) {
 team_cycle_class_participation <- function(tcc,
                                            triton.cycle,
                                            triton.classroom,
-                                           neptune.participant,
-                                           neptune.participant_data) {
+                                           participant,
+                                           complete_participant_data) {
   # Args:
   #   tcc - see team_cycle_class()
   #   triton.cycle - from db, include all cycles from tcc
   #   triton.classroom - from db, include all classes from tcc
-  #   neptune.participant - from db, include all ppts from...
-  #   neptune.participant - from db, include all relevant survey responses
-  if (nrow(neptune.participant_data) == 0) {
+  #   participant - df of participant-level info to join, with column
+  #     'participant.uid'. Might be from either neptune or triton dbs.
+  #   complete_participant_data - df of survey-response-level info, with
+  #     columns c('participant_data.participant_id', 'participant_data.code',
+  #       'participant_data.modified'), representing _complete_ survey
+  #       responses. Will be used to calculate column 'num_completed_by_pd' in
+  #       output. Might be from neptune db or saturn db.
+  #
+  # Returns: team-cycle-class-level df with added column 'num_completed_by_pd'.
+  if (nrow(complete_participant_data) == 0) {
     logging$warning("No participation data!")
     tcc$num_completed_by_pd <- 0
     return(tcc)
@@ -116,9 +123,9 @@ team_cycle_class_participation <- function(tcc,
   # won't appear here.
   # Returns team-cycle-class level data, with added cols:
   # * num_completed_by_pd ("pd" means from the participant_data table)
-  ppn <- neptune.participant_data %>%
+  ppn <- complete_participant_data %>%
     left_join(
-      neptune.participant,
+      participant,
       by = c(participant_data.participant_id = "participant.uid")
     ) %>%
     # We'll use the neptune participant data table like the saturn response

--- a/R/summarize_copilot.R
+++ b/R/summarize_copilot.R
@@ -341,6 +341,15 @@ map_responses_to_cycles <- function(response_tbl,
     )
   }
 
+  cycle_extended <- triton.cycle %>%
+    mutate(
+      cycle.extended_end_date = ifelse(
+        util$is_blank(cycle.extended_end_date),
+        cycle.end_date,
+        cycle.extended_end_date
+      )
+    )
+
   response_merged <- response_tbl %>%
     left_join(triton.classroom, by = c(code = "classroom.code")) %>%
     mutate(
@@ -355,15 +364,14 @@ map_responses_to_cycles <- function(response_tbl,
 
   # B/c we loop over every cycle, it's a big efficiency gain to make sure we're
   # considering the minimum possible set of cycles.
-  potential_cycles <- triton.cycle %>%
+  potential_cycles <- cycle_extended %>%
     filter(cycle.team_id %in% unique(response_merged$classroom.team_id)) %>%
-    filter(!util$is_blank(cycle.start_date)) %>%
-    filter(!util$is_blank(cycle.extended_end_date))
+    filter(!util$is_blank(cycle.start_date))
 
   # Fill in values of the cycle_ordinal column as their row matches various
   # cycle dates.
   for (i in sequence(nrow(potential_cycles))) {
-    this_cycle <- triton.cycle[i, ]
+    this_cycle <- potential_cycles[i, ]
     in_cycle <- (
       response_merged$created_date >= this_cycle$cycle.start_date &
         response_merged$created_date <= this_cycle$cycle.extended_end_date &

--- a/R/summarize_copilot.R
+++ b/R/summarize_copilot.R
@@ -366,9 +366,16 @@ map_responses_to_cycles <- function(response_tbl,
       cycle_ordinal = NA # Populated below.
     )
 
+  # B/c we loop over every cycle, it's a big efficiency gain to make sure we're
+  # considering the minimum possible set of cycles.
+  potential_cycles <- triton.cycle %>%
+    filter(cycle.team_id %in% unique(response_merged$classroom.team_id)) %>%
+    filter(!util$is_blank(cycle.start_date)) %>%
+    filter(!util$is_blank(cycle.extended_end_date))
+
   # Fill in values of the cycle_ordinal column as their row matches various
   # cycle dates.
-  for (i in sequence(nrow(triton.cycle))) {
+  for (i in sequence(nrow(potential_cycles))) {
     this_cycle <- triton.cycle[i, ]
     in_cycle <- (
       response_merged$created_date >= this_cycle$cycle.start_date &

--- a/tests/testthat/test_summarize_copilot.R
+++ b/tests/testthat/test_summarize_copilot.R
@@ -429,11 +429,11 @@ describe('map_responses_to_cycles', {
   )
 
   triton.cycle <- tribble(
-    ~uid,       ~team_id,     ~start_date,  ~end_date,    ~ordinal,
-    'Cycle_1',  'Team_Viper', '2020-01-01', '2020-01-14', 1,
-    'Cycle_2',  'Team_Viper', '2020-01-15', '2020-01-30', 2,
-    'Cycle_3',  'Team_Fox',   '2020-01-01', '2020-01-14', 1,
-    'Cycle_4',  'Team_Fox',   '2020-01-15', '2020-01-30', 2
+    ~uid,       ~team_id,     ~start_date,  ~extended_end_date,    ~ordinal,
+    'Cycle_1',  'Team_Viper', '2020-01-01', '2020-01-14',          1,
+    'Cycle_2',  'Team_Viper', '2020-01-15', '2020-01-30',          2,
+    'Cycle_3',  'Team_Fox',   '2020-01-01', '2020-01-14',          1,
+    'Cycle_4',  'Team_Fox',   '2020-01-15', '2020-01-30',          2
   ) %>% util$prefix_columns('cycle')
 
   triton.classroom <- tribble(


### PR DESCRIPTION
## Background

Addresses https://github.com/PERTS/rserve/issues/87

## Implementation

I used `profiler` calls to figure out where the slowdown was: inside `summarize_copilot$map_responses_to_cycles()`. It was doing a for loop over all provided cycles, which was very slow. I pre-filtered the cycles to eliminate iterations of the loop that were irrelevant.

## Along the way

* Added some documentation
* Removed an ugly rbind loop that isn't necessary any more
* Fixed a test
* Fixed application of extended date logic. This was naïvely referencing `cycle.extended_end_date` even though that property is not defined if there is no next cycle. The right way to do this is choose _either_  `extended_end_date`, or failing that, use `end_date`. This probably was dropping responses before :-(

## Testing

Existing unit tests of `map_responses_to_cycles()` pass. Testing a rds from a recent run showed ~12 seconds before this change and ~5 seconds afterward.

## Feedback

This chunk of code is obviously pretty core to our operations. I've probably spent over 8 hours working with the nuances. It's not very long; I'd appreciate a good hard look trying to understand the logic from first principles. My only excuse for not including more tests is that it's taken me too much time to get this far...