### PR TITLE
Speed up json utils

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Imports:
     pkgload (>= 1.0.2),
     RMySQL (>= 0.10.18),
     stats (>= 3.6.2),
-    stringr (>= 1.4.0)
+    stringr (>= 1.4.0),
+    tidyr (>= 1.0.1)
 Suggests:
     callr,
     devtools,

--- a/R/json_utils.R
+++ b/R/json_utils.R
@@ -87,13 +87,13 @@ expand_vector_column_ <- function (df, column_name, as_type = NULL) {
     stop(paste0("Column '", column_name, "' not found."))
   }
 
-  bound <- tidyr::unchop(df, !!column_name, keep_empty = TRUE)
+  expanded <- tidyr::unchop(df, !!column_name, keep_empty = TRUE)
 
   if (!is.null(as_type)) {
-    bound[[column_name]] <- as_type(bound[[column_name]])
+    expanded[[column_name]] <- as_type(expanded[[column_name]])
   }
 
-  return(tibble::as.tibble(bound))
+  return(tibble::as.tibble(expanded))
 }
 
 expand_string_array_column <- function (df, column_name) {

--- a/R/json_utils.R
+++ b/R/json_utils.R
@@ -83,42 +83,11 @@ expand_vector_column_ <- function (df, column_name, as_type = NULL) {
     df <- dplyr::ungroup(df)
   }
 
-  vector_column <- df[[column_name]]
-  if (is.null(vector_column)) {
+  if (is.null(df[[column_name]])) {
     stop(paste0("Column '", column_name, "' not found."))
   }
 
-  dfs_to_bind <- list()
-  for (r in 1:nrow(df)) {
-    current_vector <- vector_column[[r]]
-
-    if (length(current_vector) %in% 0) {
-      expanded <- df[r, ]
-      expanded[[column_name]] <- NA
-    } else {
-      # Expand the current row of the data frame to repeat to the same dimension
-      # as the vector.
-      expanded <- df %>% dplyr::slice(rep(r, each = length(current_vector)))
-
-      # Append the vector (which was a cell) as a _column_, now that the
-      # dimensions are correct.
-      expanded[[column_name]] <- current_vector
-    }
-
-    # Data frames ARE lists, so just concatenating them to our collection
-    # `dfs_to_bind` would actually concatenate the _columns_ of the data frame
-    # to the list. Wrapping it in list() forces R to treat the whole df as a
-    # discrete object.
-    dfs_to_bind <- c(dfs_to_bind, list(expanded))
-  }
-
-  if (length(dfs_to_bind) %in% 0) {
-    bound <- df
-  } else if (length(dfs_to_bind) %in% 1) {
-    bound <- dfs_to_bind[[1]]
-  } else {
-    bound <- do.call(rbind, dfs_to_bind)
-  }
+  bound <- tidyr::unchop(df, !!column_name, keep_empty = TRUE)
 
   if (!is.null(as_type)) {
     bound[[column_name]] <- as_type(bound[[column_name]])


### PR DESCRIPTION
We're using this function a lot to process JSON-serialized data, and it was pretty slow. I dug through the tidyverse for awhile to see how they do this kind of thing, and lo and behold: `tidyr::unchop`, part of chop/unchop and nest/unnest.

Testing with a 5000-row df, this went from ~3000 ms to ~50 ms (60x improvement).

All existing tests pass.