### PR TITLE
print profile name

### DIFF
--- a/R/profiler.R
+++ b/R/profiler.R
@@ -75,6 +75,7 @@ printable_report <- function(profile_name = .DEFAULT_NAME) {
 
   report <- c(
     "",
+    paste0("Profile: ", profile_name),
     # Width of message column should match .MAX_MESSAGE_LENGTH
     "Message                        Run Time  Total time",
     "---------------------------------------------------"


### PR DESCRIPTION
Nice to see the name of the profile when there are bunch of them in the logs.

Example:

<img width="375" alt="Screen Shot 2020-11-10 at 12 49 22 PM" src="https://user-images.githubusercontent.com/15002798/98731857-2f6f1980-2353-11eb-9153-ab82fbd90eeb.png">
