### PR TITLE
strip names before comparing vector in unit test

### DIFF
--- a/tests/testthat/test_recode_response_data/test_recode_response_data.R
+++ b/tests/testthat/test_recode_response_data/test_recode_response_data.R
@@ -111,6 +111,7 @@ describe('define_race_disadvantage', {
         race_example1_adv = c(FALSE, TRUE)
       )
     recoded <- recode_response_data$define_race_disadvantage(rd, race_config)
+    names(recoded) <- NULL
     expect_identical(recoded, c(TRUE, FALSE))
   })
 


### PR DESCRIPTION
@ sarah-gripshover-PERTS this seems to be breaking unit tests in codeship. I can't reproduce the problem locally, not sure why.

I just saw that codeship was reporting the error `names for target but not for current` so I took out the names before comparing.

When I brought this change into RServe and pushed, the [Codeship build](https://app.codeship.com/projects/1a542af0-5115-0138-2023-26b6454f2988/builds/eb7b0a19-4311-42fc-9744-6382b0f2875f?component=step_r-unit-tests) passed.

