### PR TITLE
Fix imputation again

### DIFF
--- a/tests/testthat/test_imputation/test_imputation.R
+++ b/tests/testthat/test_imputation/test_imputation.R
@@ -455,11 +455,48 @@ describe('imputation', {
 
     # assert that the imputed value for Participant_1 for q2 for 2021-03-07
     # should be 4
-    expected_q2_w2 <- rdi %>%
+    actual_q2_w2 <- rdi %>%
       filter(week_start %in% as.Date("2021-03-07"),
              question_code %in% "q2") %>%
       pull(value_imputed)
-    expect_equal(expected_q2_w2, 4)
+    expect_equal(actual_q2_w2, 4)
+  })
+
+  it('imputes across time units and participants', {
+    rd <- data.frame(
+      week_start = as.Date(c("2021-02-28", "2021-02-28", "2021-03-07")),
+      participant_id = c("Participant_1", "Participant_2", "Participant_1"),
+      q1 = c(2, 1, 3),
+      q2 = c(4, 2, NA),
+      parent_id = "Network_1"
+    )
+
+    rdi <- imputation$impute_to_time_ordinal(
+      response_data = rd,
+      imputation_index = c("participant_id", "parent_id"),
+      time_ordinal_column = "week_start",
+      cols_to_impute = c("q1", "q2"),
+      time_ordinal_scope_vars = "parent_id"
+    )
+
+    # The fact that participant 1 answered q1 at time 2 should trigger
+    # imputation of ALL questions (q1 and q2) for ALL participants (1 and 2)
+    # into time 2.
+    actual_w2 <- rdi %>%
+      filter(week_start %in% as.Date("2021-03-07")) %>%
+      select(
+        participant_id,
+        question_code,
+        value_imputed
+      )
+    expected_w2 <- dplyr::tribble(
+      ~participant_id, ~question_code, ~value_imputed,
+      "Participant_1", "q1",           3,
+      "Participant_1", "q2",           4,
+      "Participant_2", "q1",           1,
+      "Participant_2", "q2",           2,
+    )
+    expect_equal(actual_w2, expected_w2)
   })
 
 })


### PR DESCRIPTION
# Introduction

Our imputation procedure was producing the following output for a network report in which there were definitely students who completed teacher caring, affirming cultural identity, and classroom belonging survey items. However, the network was seeing this output in their report:

![image](https://user-images.githubusercontent.com/57725320/111227730-008edb80-85b1-11eb-881a-e0b26cd99a77.png)

Which is obviously wrong. I traced the issue to an oddity in how imputation handles cases where imputation is triggered to a new time ordinal by some items but not others; e.g., if Sarah is the only student from PERTS University who completes the survey in Week 2021-03-07, and she only completes half of the questions...then everybody from PERTS University will get their scores carried forward for the questions Sarah happened to complete, but not for the questions she didn't complete. This will cause the "most recent" week of imputed data to have all blank values for the items Sarah didn't complete. The last time a student from PERTS_university did any of _those_ items was 2021-02-28, so their scores on the items Sarah missed are only carried forward through week 2028-02-28.

(The reason it leads to blanks in the table is because it's not just that there are a few blanks for those items for the week of 2021-03-07, which is the most recent week. It's that there are no present values for that week from those items. Because Sarah didn't do those and nobody's scores were carried forward! Obviously undesirable in our reports. And I would argue that it's pretty unexpected for anyone who would be using this function for imputation....why would time scope only apply at a question level? Makes no sense.)

# Implementation

Fixing this was simple: 

+ 039ab7c is a failing unit test that identifies the problem to be solved.
+ 3012d56 fixes the problem. I disentangled the lines of code used to identify time scope vs. question scope. They are now defined separately for each level of the time_scope_variable.


# Testing

Once this PR is approved, I will test the Rserve side and make sure the Midwest Network's report really did get fixed. But in the meantime, in gymnast I confirm that all unit tests for the imputation module are passing.