### PR TITLE
Fix network assc

### DIFF
--- a/R/summarize_copilot.R
+++ b/R/summarize_copilot.R
@@ -623,7 +623,9 @@ get_classrooms_from_network <- function (network_ids,
     classroom.uid = character(),
     classroom.code = character(),
   )
-
+  # We iterate over all elements in network_assc$network.uid rather than the
+  # unique elements in network_assc$network id because we want to go through each
+  # row in the data.frame; that is, each network/child combination.
   for (x in sequence(length(network_assc$network.uid))) {
     network_id <- network_assc$network.uid[x]
     network_name <- network_assc$network.name[x]
@@ -664,9 +666,9 @@ get_classrooms_from_network <- function (network_ids,
           child_name = !!child_name
         )
     }
-
+    # save the added rows
     classroom_assc <- rbind(classroom_assc, to_add)
   }
 
-  distinct(classroom_assc, child_id, classroom.uid, .keep_all = TRUE)
+  unique(classroom_assc)
 }

--- a/R/summarize_copilot.R
+++ b/R/summarize_copilot.R
@@ -670,5 +670,10 @@ get_classrooms_from_network <- function (network_ids,
     classroom_assc <- rbind(classroom_assc, to_add)
   }
 
-  unique(classroom_assc)
+  # Network associations are serialized in the database and aren't
+  # guaranteed to be unique, e.g. you could have association_ids
+  # as ["Org_A","Org_B","Org_A"]. Protect against duplicated
+  # relationships by calling unique().
+
+  return(unique(classroom_assc))
 }


### PR DESCRIPTION
# Description

Rserve was missing network-org combos where the same org was a member of multiple networks. 

# Implementation

Instead of taking the unique set of child_id and classroom.uid values, we take the unique rows of the whole association table (9e709cc). This avoids throwing out rows where the child is nested under more than one parent.

# Testing

9e709cc now passes. Hooray! I will do larger scale tests to make sure it interacts well with Rserve when I update the Rserve submodule inside my working branch.