### PR TITLE
Check the uniqueness of the data before imputing

### DIFF
--- a/R/imputation.R
+++ b/R/imputation.R
@@ -71,6 +71,16 @@ impute_to_time_ordinal <- function(
     stop("The time ordinal column was not found in the response data: " %+% time_ordinal_column)
   }
 
+  index_is_duplicated <- response_data %>%
+    select(all_of(c(imputation_index, time_ordinal_column))) %>%
+    duplicated()
+
+  if(any(index_is_duplicated)){
+    stop("Your imputation_index did not specify unique values within the time_ordinal column. " %+%
+           "No imputation can be performed until your response_data object contains " %+%
+           "unique values of " %+% paste0(c(imputation_index, time_ordinal_column), collapse = ", "))
+  }
+
   # handle NSE by hard-coding `time_ordinal_column` as the values in "time_ordinal_column"
   response_data$time_ordinal_column <- response_data[[time_ordinal_column]]
   melt_ids <- c(imputation_index, "time_ordinal_column")

--- a/R/imputation.R
+++ b/R/imputation.R
@@ -64,7 +64,7 @@ impute_to_time_ordinal <- function(
   if(!all(imputation_index %in% names(response_data))){
     missing_cols <- imputation_index[!imputation_index %in% names(response_data)]
     stop("The following columns in the imputation index were not found in the response data: " %+%
-           paste0(missing_cols))
+           paste0(missing_cols, collapse = ", "))
   }
 
   if(!time_ordinal_column %in% names(response_data)){

--- a/R/imputation.R
+++ b/R/imputation.R
@@ -61,6 +61,16 @@ impute_to_time_ordinal <- function(
            "so these are required to appear in the imputation_index.")
   }
 
+  if(!all(imputation_index %in% names(response_data))){
+    missing_cols <- imputation_index[!imputation_index %in% names(response_data)]
+    stop("The following columns in the imputation index were not found in the response data: " %+%
+           paste0(missing_cols))
+  }
+
+  if(!time_ordinal_column %in% names(response_data)){
+    stop("The time ordinal column was not found in the response data: " %+% time_ordinal_column)
+  }
+
   # handle NSE by hard-coding `time_ordinal_column` as the values in "time_ordinal_column"
   response_data$time_ordinal_column <- response_data[[time_ordinal_column]]
   melt_ids <- c(imputation_index, "time_ordinal_column")

--- a/R/imputation.R
+++ b/R/imputation.R
@@ -113,28 +113,17 @@ impute_to_time_ordinal <- function(
     filter(!is.na(value)) %>%
     rename(question_code = variable)
 
-  # retain only one response if a participant
-  # has multiple responses in a given level of time_ordinal_column
-  responses_melted_last <- responses_melted %>%
-    group_by(.dots = c(imputation_index, "time_ordinal_column", "question_code")) %>%
-    # For medium-quality reasons, we don't care which value we select within the
-    # time ordinal within participants, because the data should have been
-    # filtered to complete responses already. In the future it might be great to
-    # have a principled way of selecting these, though.
-    summarise(value = last(value)) %>%
-    ungroup()
-
   # In what time ordinals did each unit actively collect data?
   # If a student is missing data from a a week in which
   # their unit was collecting data, data will need to be imputed for that
   # time ordinal combination for that student/code.
-  active_time_ordinals <- responses_melted_last %>%
+  active_time_ordinals <- responses_melted %>%
     # take all values of the combined index, EXCLUDING participants (because we
     # want to impute over participants)
     select(all_of(time_ordinal_scope_vars), time_ordinal_column) %>%
     distinct()
 
-  active_questions <- responses_melted_last %>%
+  active_questions <- responses_melted %>%
     select(all_of(time_ordinal_scope_vars), question_code) %>%
     distinct()
 
@@ -154,7 +143,7 @@ impute_to_time_ordinal <- function(
   # rmv = responses, melted, variables
   rmv <- left_join(
     imputation_base,
-    responses_melted_last,
+    responses_melted,
     by=c(imputation_index, "time_ordinal_column", "question_code"))
 
   # rmvi = responses, melted, variables

--- a/tests/testthat/test_imputation/test_imputation.R
+++ b/tests/testthat/test_imputation/test_imputation.R
@@ -499,6 +499,48 @@ describe('imputation', {
     expect_equal(actual_w2, expected_w2)
   })
 
+  it('throws an informative error when imputation index columns are not present', {
+    rd <- data.frame(
+      week_start = as.Date(c("2021-02-28", "2021-03-07")),
+      participant_id = c("Participant_1", "Participant_1"),
+      q1 = c(2, 3),
+      q2 = c(4, 3)
+    )
+
+    expect_error(
+      imputation$impute_to_time_ordinal(
+        response_data = rd,
+        imputation_index = c("participant_id", "parent_id"),
+        time_ordinal_column = "week_start",
+        cols_to_impute = c("q1", "q2"),
+        time_ordinal_scope_vars = "parent_id"
+      ),
+      regexp = "columns in the imputation index were not found"
+    )
+
+  })
+
+  it('throws an informative error when time ordinal columns are not present', {
+    rd <- data.frame(
+      participant_id = c("Participant_1", "Participant_1"),
+      q1 = c(2, 3),
+      q2 = c(4, 3),
+      parent_id = "Network_1"
+    )
+
+    expect_error(
+      imputation$impute_to_time_ordinal(
+        response_data = rd,
+        imputation_index = c("participant_id", "parent_id"),
+        time_ordinal_column = "week_start",
+        cols_to_impute = c("q1", "q2"),
+        time_ordinal_scope_vars = "parent_id"
+      ),
+      regexp = "time ordinal column was not found"
+    )
+
+  })
+
   it('checks the uniqueness of the imputation index and throws an error if it is not unique', {
     rd <- data.frame(
       week_start = as.Date(c("2021-02-28", "2021-03-07", "2021-03-07")),

--- a/tests/testthat/test_imputation/test_imputation.R
+++ b/tests/testthat/test_imputation/test_imputation.R
@@ -499,4 +499,25 @@ describe('imputation', {
     expect_equal(actual_w2, expected_w2)
   })
 
+  it('checks the uniqueness of the imputation index and throws an error if it is not unique', {
+    rd <- data.frame(
+      week_start = as.Date(c("2021-02-28", "2021-03-07", "2021-03-07")),
+      participant_id = c("Participant_1", "Participant_1", "Participant_1"),
+      q1 = c(2, 3, 4),
+      q2 = c(4, 3, 4),
+      parent_id = "Network_1"
+    )
+    imputation_index_and_time_ordinal = c("participant_id", "parent_id", "week_start")
+    # prove that the last row duplicates values of the imputation index within time ordinal
+    expect_equal(duplicated(rd[c(imputation_index_and_time_ordinal)]), c(FALSE, FALSE, TRUE))
+
+    expect_error(imputation$impute_to_time_ordinal(
+      response_data = rd,
+      imputation_index = c("participant_id", "parent_id"),
+      time_ordinal_column = "week_start",
+      cols_to_impute = c("q1", "q2"),
+      time_ordinal_scope_vars = "parent_id"
+    ))
+  })
+
 })

--- a/tests/testthat/test_imputation/test_imputation.R
+++ b/tests/testthat/test_imputation/test_imputation.R
@@ -541,7 +541,7 @@ describe('imputation', {
 
   })
 
-  it('checks the uniqueness of the imputation index and throws an error if it is not unique', {
+  it('checks the uniqueness of the imputation index within the time ordinal and throws an error if it is not unique', {
     rd <- data.frame(
       week_start = as.Date(c("2021-02-28", "2021-03-07", "2021-03-07")),
       participant_id = c("Participant_1", "Participant_1", "Participant_1"),
@@ -549,8 +549,9 @@ describe('imputation', {
       q2 = c(4, 3, 4),
       parent_id = "Network_1"
     )
-    imputation_index_and_time_ordinal = c("participant_id", "parent_id", "week_start")
+
     # prove that the last row duplicates values of the imputation index within time ordinal
+    imputation_index_and_time_ordinal = c("participant_id", "parent_id", "week_start")
     expect_equal(duplicated(rd[c(imputation_index_and_time_ordinal)]), c(FALSE, FALSE, TRUE))
 
     expect_error(imputation$impute_to_time_ordinal(

--- a/tests/testthat/test_imputation/test_imputation.R
+++ b/tests/testthat/test_imputation/test_imputation.R
@@ -563,4 +563,51 @@ describe('imputation', {
     ))
   })
 
+  it('gives the same answer no matter how the data is sorted', {
+    rd_order1 <- data.frame(
+      week_start = as.Date(c("2021-02-28", "2021-03-07", "2021-03-07")),
+      participant_id = c("Participant_1", "Participant_1", "Participant_2"),
+      q1 = c(2, 3, 4),
+      q2 = c(4, 3, 4),
+      parent_id = "Network_1"
+    )
+
+    rd_order2 <- data.frame(
+      week_start = as.Date(c( "2021-03-07", "2021-02-28", "2021-03-07")),
+      participant_id = c( "Participant_2", "Participant_1", "Participant_1"),
+      q1 = c(4, 2, 3),
+      q2 = c(4, 4, 3),
+      parent_id = "Network_1"
+    )
+
+    # prove that they are the same data.frames in different order
+    # row 1 order 1 is equivalent to row 2 order 2
+    expect_equal(unlist(rd_order1[1, ]), unlist(rd_order2[2, ]))
+    # row 2 order 1 is equivalent to row 3 order 2
+    expect_equal(unlist(rd_order1[2, ]), unlist(rd_order2[3, ]))
+    # row 3 order 1 is equivalent to row 1 order 2
+    expect_equal(unlist(rd_order1[3, ]), unlist(rd_order2[1, ]))
+
+    # impute them both
+    rd_order1_imputed <- imputation$impute_responses_downup(
+      rd_order1,
+      imputation_index = c("participant_id", "parent_id"),
+      time_ordinal_column = "week_start",
+      cols_to_impute = c("q1", "q2"),
+      time_ordinal_scope_vars = "parent_id"
+    )
+
+    rd_order2_imputed <- imputation$impute_responses_downup(
+      rd_order2,
+      imputation_index = c("participant_id", "parent_id"),
+      time_ordinal_column = "week_start",
+      cols_to_impute = c("q1", "q2"),
+      time_ordinal_scope_vars = "parent_id"
+    )
+
+    # prove they are the same
+    expect_equal(rd_order1_imputed, rd_order2_imputed)
+
+  })
+
 })


### PR DESCRIPTION
# Introduction

A bug was introduced by the imputation function calling `last()` on data that may not be unique by the group_by. Doing this causes imputation behavior to shift based on the sorting of the data.frame! Bad news.

# Implementation

Imputation should be happening on clean data. If there are duplicate values of the implementation index, these should be handled prior to imputation. Why? Because different scenarios might have different inclusion criteria, for one. In Rserve, we might want to always take participants' LAST response in the participation window. But certain analyses may wish to take first responses, to take a mean of all responses, etc.

More generally, it is beyond the scope of what we mean when we say "imputation" to perform this basic data processing. Any procedure we could come up with here would undoubtedly produce surprising behavior in some circumstances. Therefore, we simply throw an error when this basic data processing has not been performed and call it a day.

+ 2e6be21 is a failing test to check for an error being thrown when the imputation index is not unique.
+ f403191 makes the above test pass by stopping if the imputation index is duplicated within the time ordinal
+ 8e6e008 deletes the `last()` operation altogether because it's no longer needed (we don't need to disambiguate rows if we already know they're unique)
+ A few more things...
    - 0cb49c0 just goes ahead and writes an informative error for any expected but missing columns. (An error was already being thrown for missing columns, but it wasn't informative.)
    - 8fedfa2 and f6bad0a were minor clean-up things

# Testing
All unit tests, including the new ones described above, now pass.