### PR TITLE
feat: this code just makes tons of noise, removing

### DIFF
--- a/R/summarize_copilot.R
+++ b/R/summarize_copilot.R
@@ -304,17 +304,6 @@ map_responses_to_cycles <- function(response_tbl,
     stop("map_responses_to_cycles would overwrite columns")
   }
 
-  missing_codes <- unique(
-    response_tbl$code[!response_tbl$code %in% triton.classroom$classroom.code]
-  )
-  if (length(missing_codes) > 0) {
-    logging$info(
-      "These participation codes don't appear in Copilot, most likely from",
-      "deleted classrooms: ",
-      missing_codes
-    )
-  }
-
   cycle_extended <- triton.cycle %>%
     mutate(
       cycle.extended_end_date = ifelse(


### PR DESCRIPTION
## Background

When the existing code tries to place each response within a cycle, it has a complete set of possibly applicable participation codes for the whole request, but it processes responses per-report, which means in the vast majority of cases, most codes appear "missing", just because they appear in reports other than the current one. That means this error makes a ton of logging noise.

## Implementation

Stop logging a warning and treat this like normal behavior.

## Feedback

Maybe we want an error like this to check for classrooms we expected to find by didn't somewhere else? If you can think of where, let me know.