### PR TITLE
Update str pct utility

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -319,9 +319,10 @@ clean_percent <- function(numerator, denominator, blank_value = 0) {
   ifelse(is_blank, blank_value, raw_pct)
 }
 
-str_percent <- function(numerator, denominator, blank_value = 'N/A') {
+str_percent <- function(numerator, denominator, blank_value = 'N/A', use_percent_sign = TRUE) {
   raw_pct <- clean_percent(numerator, denominator, blank_value = NA)
-  ifelse(is.na(raw_pct), blank_value, paste0(as.character(raw_pct), '%'))
+  percent_sign <- ifelse(use_percent_sign, '%', '')
+  ifelse(is.na(raw_pct), blank_value, paste0(as.character(raw_pct), percent_sign))
 }
 
 

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -60,4 +60,8 @@ describe('str_percent', {
 
     expect_identical(d$pct_ab, c('50%', '67%', '75%'))
   })
+
+  it('does not return a pct sign when asked not to',{
+    expect_equal(util$str_percent(1, 2, use_percent_sign = FALSE), '50')
+  })
 })


### PR DESCRIPTION
## Background
In some cases we may want to have string percentages that do not actually have the percent sign appended (as in the case of percentage point change). 

## Implementation
[As suggested here](https://github.com/PERTS/rserve/pull/200#discussion_r682945505)  - Added scope to `str_percent` function to allow for repression of percent sign through argument `use_percent_sign` which defaults to true.

## Testing
Added in new test to test_util.R to ensure that percent sign is inhibited when requested.


