### PR TITLE
Allow local connection to saturn db

### DIFF
--- a/R/saturn.R
+++ b/R/saturn.R
@@ -175,14 +175,7 @@ create_service <- function (
   }
 
   return(list(
-    get_responses = ifelse(
-      is.null(credentials),
-      function (...) {
-        print("saturn service has no credentials, returning empty data frame.")
-        return(data.frame())
-      },
-      get_responses
-    ),
+    get_responses = get_responses,
     get_raw_responses = get_raw_responses,
     fake_responses = fake_responses,
     query = query


### PR DESCRIPTION
## Background

Getting RServe ready for 2021. Found that without SSL credentials, the saturn.R service would refuse to pull any data.

## Implementation

Since SSL credentials—which allow encrypted connections—aren't needed on localhost (when developing on your own machine), it's normal not to provide them when testing. I removed the code that was always returning an empty data frame in this case.

## Testing

When running RServe locally, I was able to import saturn responses from my local db.

