### PR TITLE
feat: util$datetime_to_iso_string()

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -564,3 +564,9 @@ find_day_of_week <- function (increment, day_abbr) {
 
 next_monday <- function() find_day_of_week(+1, "Mon")
 last_monday <- function() find_day_of_week(-1, "Mon")
+
+datetime_to_iso_string <- function (datetime = Sys.time()) {
+  # Takes optional POSIXct (e.g. Sys.time()), defaults to current time.
+  # Returns length-1 character, ISO 8601 format, in UTC.
+  format(datetime, format="%Y-%m-%dT%H:%M:%SZ", tz="GMT")
+}


### PR DESCRIPTION
## Background

We use datetime formats like this: `2021-08-23T21:45:40Z` but I was having a hard time getting R to spit this out. Even `lubridate` was failing me, because it wouldn't accept my specified timezone:

```
> lubridate::format_ISO8601(Sys.time(), tz="GMT", usetz=TRUE)
[1] "2021-08-23T14:22:59-0700"
```

## Implementation

Made a util function to format this the standard PERTS way. Can format any provided datetime or return the current time.

```
> util$datetime_to_iso_string()
[1] "2021-08-23T22:09:41Z"
```