### PR TITLE
Expand across subset type

### DIFF
--- a/R/sanitize_display.R
+++ b/R/sanitize_display.R
@@ -13,7 +13,7 @@ expand_subsets_agm_df <- function(
   desired_subset_config,
   time_ordinal_column,
   combined_index = c("reporting_unit_id", "metric", "subset_value"),
-  unpropagated_fields = c("pct_good", "se", "n", "disadv"),
+  unpropagated_fields = c("pct_good", "se", "n", "disadv", "mean_value"),
   cols_varying_by_subset_type = c("p", "grand_mean")
 ){
   # this function expands the agm objects to include ALL subset_values specified

--- a/R/sanitize_display.R
+++ b/R/sanitize_display.R
@@ -28,8 +28,8 @@ expand_subsets_agm_df <- function(
   # "Masked" from gender to race subset_values!
 
   # first make sure the combined_index is valid
-  combined_index <- c(combined_index, time_ordinal_column)
-  missing_index <- combined_index[!combined_index %in% names(agm_df_ungrouped)]
+  comb_index_time <- c(combined_index, time_ordinal_column)
+  missing_index <- comb_index_time[!comb_index_time %in% names(agm_df_ungrouped)]
   if(length(missing_index) > 0){
     stop(
       "In expand_subsets_agm_df, some indexes were missing: " %+%
@@ -37,7 +37,7 @@ expand_subsets_agm_df <- function(
     )
   }
 
-  if(!any(combined_index %in% "subset_value")){
+  if(!any(comb_index_time %in% "subset_value")){
     stop("In expand_subsets_agm_df, subset_value must appear in the combined index.")
   }
 
@@ -61,20 +61,20 @@ expand_subsets_agm_df <- function(
   # identify which subsets need to be propagated. Which ones are missing from
   # some combination of the index variables?
 
-  expand_vars <- combined_index[!combined_index %in% "subset_value"]
+  expand_vars <- comb_index_time[!comb_index_time %in% "subset_value"]
   complete_subsets <- tidyr::expand_grid(
     agm_df_ungrouped[expand_vars],
     subset_value = c(desired_subset_config$subset_value, "All Students")
     ) %>%
     unique()
 
-  observed_subsets <- agm_df_ungrouped[combined_index] %>%
+  observed_subsets <- agm_df_ungrouped[comb_index_time] %>%
     dplyr::mutate(present = TRUE)
 
   merged_subsets <- dplyr::left_join(
     complete_subsets,
     observed_subsets,
-    by = combined_index,
+    by = comb_index_time,
     suffix = c("_complete", "_observed")
   )
   if(!nrow(merged_subsets) == nrow(complete_subsets)){

--- a/R/sanitize_display.R
+++ b/R/sanitize_display.R
@@ -141,6 +141,24 @@ expand_subsets_agm_df <- function(
     select(all_of(c(index_sans_sv, propagated_by_subset_cols, "subset_type"))) %>%
     unique()
 
+  ########################
+  # make sure propagation will not result in a duplicated index
+
+  # propagated_by_index_df should have the same number of unique rows as those
+  # defined by the index_sans_sv. Throw an error if not because that will eff
+  # everything up
+  expected_index_df_nrows <- agm_df_ungrouped %>%
+    select(all_of(index_sans_sv)) %>%
+    unique() %>%
+    nrow()
+
+  if(expected_index_df_nrows != nrow(propagated_by_index_df)){
+    stop("The columns set to be propagated by the combined index are not " %+%
+           "unique within the combined index. Subgroup expansion could not be " %+%
+           "performed. Please check the inputs to unpropagated_fields " %+%
+           "and combined_index and try again.")
+  }
+
   new_subsets_propagated <- new_subsets_grid %>%
     dplyr::left_join(
       .,

--- a/R/sanitize_display.R
+++ b/R/sanitize_display.R
@@ -13,8 +13,8 @@ expand_subsets_agm_df <- function(
   desired_subset_config,
   time_ordinal_column,
   combined_index = c("reporting_unit_id", "metric", "subset_value"),
-  unpropagated_fields = c("pct_good", "se", "n"),
-  cols_varying_by_subset_type = c("grand_mean")
+  unpropagated_fields = c("pct_good", "se", "n", "disadv"),
+  cols_varying_by_subset_type = c("p", "grand_mean")
 ){
   # this function expands the agm objects to include ALL subset_values specified
   # by the desired_subset_config.
@@ -56,15 +56,6 @@ expand_subsets_agm_df <- function(
       "desired_subset_config. This allows merging on that key. " %+%
       "Please fix the config file or the agm values before proceeding. "
     )
-  }
-  # make sure the unpropagated_fields are valid
-  unpropagated_fields <- c(unpropagated_fields, "subset_value")
-  missing_unpropagated <- unpropagated_fields[
-    !unpropagated_fields %in% names(agm_df_ungrouped)
-  ]
-  if(length(missing_unpropagated) > 0){
-    stop("In expand_subsets_agm_df, some unpropagated fields were missing: " %+%
-           paste0(missing_unpropagated, collapse = ", "))
   }
 
   # identify which subsets need to be propagated. Which ones are missing from

--- a/R/sanitize_display.R
+++ b/R/sanitize_display.R
@@ -159,6 +159,25 @@ expand_subsets_agm_df <- function(
            "and combined_index and try again.")
   }
 
+  # propagated_by_subset_df should have the same unique rows as those defined by
+  # the index_sans_sv plus subset_type. Throw an error if not because that, too,
+  # will eff everything up
+
+  expected_subset_df_nrows <- agm_df_ungrouped %>%
+    select(all_of(c(index_sans_sv, "subset_type"))) %>%
+    unique() %>%
+    nrow()
+
+  if(expected_subset_df_nrows != nrow(propagated_by_subset_df)){
+    stop("The columns set to be propagated by the combined index are not " %+%
+           "unique within the combined index plus subset_type. Subgroup expansion could not be " %+%
+           "performed. Please check the inputs to cols_varying_by_subset_type " %+%
+           "and combined_index and try again.")
+  }
+
+  ########################
+
+
   new_subsets_propagated <- new_subsets_grid %>%
     dplyr::left_join(
       .,

--- a/tests/testthat/test_sanitize_display.R
+++ b/tests/testthat/test_sanitize_display.R
@@ -437,6 +437,43 @@ describe('expand_subsets_agm_df',{
                    "unique within the combined index.")
 
   })
+
+  it('throws an error where propagation by combined index and subset_type will lead to a duplicated index', {
+    # This test is the same as the one above, but specifically varies the extra
+    # col WITHIN subset type, and sets the extra col to be propagated within subset_type only
+
+    agm <- data.frame(
+      reporting_unit_id = "Organization_1",
+      subset_type = c("gender", "gender"),
+      subset_value = c("Boy/Man", "Girl/Woman"),
+      pct_good = .5,
+      metric = "item1",
+      cycle_ordinal = 1,
+      extra_col = c(1, 2)
+    )
+
+    # the extra_col varies within the combined_index AND subset_type
+    ec_summary <- agm %>%
+      group_by(reporting_unit_id, subset_type, metric, cycle_ordinal) %>%
+      summarise(n_distinct_extra_col = n_distinct(extra_col)) %>%
+      ungroup()
+
+    # note the two distinct values
+    expect_equal(ec_summary$n_distinct_extra_col, 2)
+
+
+    subset_config <- data.frame(subset_type = c("gender", "gender", "race", "race"),
+                                subset_value = c("Girl/Woman", "Boy/Man",
+                                                 "Race Struct. Adv. ", "Race Struct. Disadv."))
+
+    expect_error(sanitize_display$expand_subsets_agm_df(agm_df_ungrouped = agm,
+                                                        desired_subset_config = subset_config,
+                                                        time_ordinal_column = "cycle_ordinal",
+                                                        cols_varying_by_subset_type = "extra_col"),
+                 regexp = "The columns set to be propagated by the combined index are not " %+%
+                   "unique within the combined index.")
+  })
+
 })
 
 

--- a/tests/testthat/test_sanitize_display.R
+++ b/tests/testthat/test_sanitize_display.R
@@ -124,7 +124,7 @@ describe('expand_subsets_agm_df',{
   agm <- sanitize_display$simulate_agm(subset_config_no_male)
   agm_expanded <- agm %>%
     sanitize_display$expand_subsets_agm_df(
-      subset_config_default,
+      desired_subset_config = subset_config_default,
       time_ordinal_column = "cycle_name"
     )
   default_combined_index <- c("reporting_unit_id", "cycle_name", "subset_value", "metric")

--- a/tests/testthat/test_sanitize_display.R
+++ b/tests/testthat/test_sanitize_display.R
@@ -266,6 +266,90 @@ describe('expand_subsets_agm_df',{
       )
     )
   })
+
+  it('propagates accurately when an entire subset_type is missing', {
+
+    agm <- data.frame(
+      reporting_unit_id = "Organization_1",
+      reporting_unit_type = "child_id",
+      subset_type = c("race", "race", "All Students"),
+      subset_value = c("Race Struct. Disadv.", "Race Struct. Adv. ", "All Students"),
+      pct_good = c(.5, .5, .5),
+      metric = "item1",
+      cycle_ordinal = 1,
+      se = .01,
+      n = c(10, 10, 20)
+    )
+
+    subset_config <- data.frame(
+      subset_type = c("race", "race", "gender", "gender"),
+      subset_value = c("Race Struct. Disadv.", "Race Struct. Adv. ",
+                       "Girl/Woman", "Boy/Man")
+    )
+
+    # gender is NOT one of the subset_types in agm
+    expect_false("gender" %in% agm$subset_type)
+
+    # but gender IS one of the subset_types in the subset_config
+    expect_true("gender" %in% subset_config$subset_type)
+
+    agm_expanded <- sanitize_display$expand_subsets_agm_df(
+      agm_df_ungrouped = agm,
+      desired_subset_config = subset_config,
+      time_ordinal_column = "cycle_ordinal"
+    )
+
+    # reporting_unit_type is one of the fields that's supposed to be propagated.
+    # It's a stand-in for similar fields that are also supposed to be propagated.
+    expected_reporting_unit_type <- rep("child_id", nrow(agm_expanded))
+    actual_reporting_unit_type <- agm_expanded$reporting_unit_type
+
+    expect_equal(expected_reporting_unit_type, actual_reporting_unit_type)
+
+  })
+
+  it('propagates accurately when the "All Students" row is missing', {
+    agm <- data.frame(
+      reporting_unit_id = "Organization_1",
+      reporting_unit_type = "child_id",
+      subset_type = c("race", "race"),
+      subset_value = c("Race Struct. Disadv.", "Race Struct. Adv. "),
+      pct_good = c(.5, .5),
+      metric = "item1",
+      cycle_ordinal = 1,
+      se = .01,
+      n = c(10, 10)
+    )
+
+    subset_config <- data.frame(
+      subset_type = c("race", "race", "gender", "gender"),
+      subset_value = c("Race Struct. Disadv.", "Race Struct. Adv. ",
+                       "Girl/Woman", "Boy/Man")
+    )
+
+    # All Students is NOT one of the subset_types in agm
+    expect_false("All Students" %in% agm$subset_type)
+
+    agm_expanded <- sanitize_display$expand_subsets_agm_df(
+      agm_df_ungrouped = agm,
+      desired_subset_config = subset_config,
+      time_ordinal_column = "cycle_ordinal"
+    )
+
+    # "All Students" IS in agm_expanded$subset_type and subset_value
+    expect_true("All Students" %in% agm_expanded$subset_type)
+    expect_true("All Students" %in% agm_expanded$subset_value)
+
+    # reporting_unit_type is one of the fields that's supposed to be propagated.
+    # It's a stand-in for similar fields that are also supposed to be propagated.
+    expected_reporting_unit_type <- rep("child_id", nrow(agm_expanded))
+    actual_reporting_unit_type <- agm_expanded$reporting_unit_type
+
+    expect_equal(expected_reporting_unit_type, actual_reporting_unit_type)
+
+
+  })
+
 })
 
 


### PR DESCRIPTION
# Introduction

**"Too long; didn't read" version:** there's some really boring and annoying behavior in the `expand_subsets_agm_df()` function, and I fixed it.

**Long version:** In order to sanitize the agm object for display, an expansion must be performed so that every reporting unit/cycle_ordinal/metric combination has rows for ALL of the expected subset_values. For example, if there's a reporting unit with no students in the Target Group, we need to fill in a row for target group students where n = 0 and pct_good = NA, etc. This allows us to do things like display grayed-out bars for subsets that don't exist in the data; e.g., even if there are no target group students, you still see a bar (grayed-out) for target group students. 

But when we "fill in" these missing subset values, we need to use the rest of the dataset to figure out what other values would be. For example, consider a column like "reporting_unit_type." This column indicates whether the value for reporting_unit_id in a given row corresponds to a class_id, team_id, or child_id or parent_id. If we add a new row for Target Group students (_n_ = 0), we need to decide what goes in the "reporting_unit_type" columns, as well as in any other columns that might be lurking around in the agm dataset.

Fortunately, we know what the missing values should be! For the vast majority of columns, the value should be whatever value appears for other members of the same combined index. For example, if this Target Group row corresponds to Organization_1, cycle_ordinal 1, and metric 1 ... well, then we can just take whatever value appears in all the other Organization_1, cycle_ordinal 1, and metric 1 columns. Problem solved! (A handful of columns have truly unique values, and these are specified in the input parameter `unpropagated_fields`. These do not get propagated.)

Except that use case tests revealed that propagation was not being done effectively for subset_types that were wholly missing from an entire reporting unit. For example, if Organization_1 had only Boy/Man students, propagating to Girl/Woman was no problem. But if Organization_1 had _no_ students answer the gender question (so, zero Girl/Woman and zero Boy/Man), values for columns like "reporting_unit_type" were not getting propagated. (This surfaced in a check that made sure the child agm object had only one value in the "reporting_unit_type" field — there were NAs in that field.)

Furthermore (and even more concerning), additional fiddling revealed that the function didn't complain when there was more than one distinct value within the propagation index! For example, if Organization_1, cycle_ordinal 1 and metric 1 all had different values for "reporting_unit_type," it would propagate ALL of them and not tell you about it. Undesirable!

# Implementation

This PR does three things:

1. It separates out the fields that get propagated by the combined_index, from fields that must only be propagated within subset_type. Many fields (such as "reporting_unit_type") will be the same for a given reporting unit/cycle/metric combination, even for different subset_types. E.g., gender rows and race rows from the same reporting unit will have the same value in reporting_unit_type field. But fields like p-values and the grand_mean field are specific to a subset_type. This fixes the problem with the reporting_unit_type columns. a286496 , tests here: a17f628
2. It makes the function throw an error when the propagation configuration specified in the function arguments is going to result in a duplicated index in the output data. 8f93262 , 4ddb04a
3. It adds an offending column, "mean_value" to the list of fields NOT to propagate by default (this was causing errors in the use case tests). be279d5

# Testing

+ New unit tests were written to test the new behavior and confirm the new error message.
+ Code was pulled into Rserve branch to ensure that all use case and unit tests pass there as well.