### PR TITLE
Extended start date

### DIFF
--- a/R/summarize_copilot.R
+++ b/R/summarize_copilot.R
@@ -310,6 +310,11 @@ map_responses_to_cycles <- function(response_tbl,
         util$is_blank(cycle.extended_end_date),
         cycle.end_date,
         cycle.extended_end_date
+      ),
+      cycle.extended_start_date = ifelse(
+        util$is_blank(cycle.extended_start_date),
+        cycle.start_date,
+        cycle.extended_start_date
       )
     )
 
@@ -329,14 +334,14 @@ map_responses_to_cycles <- function(response_tbl,
   # considering the minimum possible set of cycles.
   potential_cycles <- cycle_extended %>%
     filter(cycle.team_id %in% unique(response_merged$classroom.team_id)) %>%
-    filter(!util$is_blank(cycle.start_date))
+    filter(!util$is_blank(cycle.extended_start_date))
 
   # Fill in values of the cycle_ordinal column as their row matches various
   # cycle dates.
   for (i in sequence(nrow(potential_cycles))) {
     this_cycle <- potential_cycles[i, ]
     in_cycle <- (
-      response_merged$created_date >= this_cycle$cycle.start_date &
+      response_merged$created_date >= this_cycle$cycle.extended_start_date &
         response_merged$created_date <= this_cycle$cycle.extended_end_date &
         response_merged$classroom.team_id %in% this_cycle$cycle.team_id
     )

--- a/R/summarize_copilot.R
+++ b/R/summarize_copilot.R
@@ -332,6 +332,16 @@ map_responses_to_cycles <- function(response_tbl,
 
   # B/c we loop over every cycle, it's a big efficiency gain to make sure we're
   # considering the minimum possible set of cycles.
+  #   This considers 3 cases:
+  #
+  # 1. This is an ordinal = 1 cycle, where extended_start_date was set by Copilot.
+  # This is kept by the filter. Even if this cycle's other dates are unset, we
+  # will want assign responses to it by default.
+  # 2. This is an ordinal > 1 cycle where start_date was set by the user. Kept by the
+  # filter because code above copied this value into extended_start_date.
+  # 3. This is an ordinal > 1 cycle where neither start_date nor extended_start_date
+  # were are set. These are excluded by the filter because we never want to assign
+  # responses to them.
   potential_cycles <- cycle_extended %>%
     filter(cycle.team_id %in% unique(response_merged$classroom.team_id)) %>%
     filter(!util$is_blank(cycle.extended_start_date))

--- a/tests/testthat/test_summarize_copilot.R
+++ b/tests/testthat/test_summarize_copilot.R
@@ -469,11 +469,11 @@ describe('map_responses_to_cycles', {
   )
 
   triton.cycle <- tribble(
-    ~uid,       ~team_id,     ~start_date,  ~extended_end_date,    ~ordinal,
-    'Cycle_1',  'Team_Viper', '2020-01-01', '2020-01-14',          1,
-    'Cycle_2',  'Team_Viper', '2020-01-15', '2020-01-30',          2,
-    'Cycle_3',  'Team_Fox',   '2020-01-01', '2020-01-14',          1,
-    'Cycle_4',  'Team_Fox',   '2020-01-15', '2020-01-30',          2
+    ~uid,       ~team_id,     ~start_date,  ~extended_end_date,    ~ordinal,  ~extended_start_date,
+    'Cycle_1',  'Team_Viper', '2020-01-01', '2020-01-14',          1,         '',
+    'Cycle_2',  'Team_Viper', '2020-01-15', '2020-01-30',          2,         '',
+    'Cycle_3',  'Team_Fox',   '2020-01-01', '2020-01-14',          1,         '',
+    'Cycle_4',  'Team_Fox',   '2020-01-15', '2020-01-30',          2,         '',
   ) %>% util$prefix_columns('cycle')
 
   triton.classroom <- tribble(

--- a/tests/testthat/test_summarize_copilot.R
+++ b/tests/testthat/test_summarize_copilot.R
@@ -581,9 +581,9 @@ describe('map_responses_to_cycles', {
 
   it('uses start_date_extended when start_date is absent', {
     triton.cycle <- tribble(
-      ~uid,       ~team_id,     ~start_date,  ~extended_end_date,    ~ordinal,  ~extended_start_date,
-      'Cycle_1',  'Team_Viper', '',           '2020-01-14',          1,         '2019-06-30',
-      'Cycle_2',  'Team_Viper', '2020-01-15', '2020-01-30',          2,         ''
+      ~uid,       ~team_id,     ~extended_start_date, ~start_date,  ~extended_end_date, ~end_date, ~ordinal,
+      'Cycle_1',  'Team_Viper', '2019-06-30',         NA,           '2020-01-14',       NA,        1,
+      'Cycle_2',  'Team_Viper', NA,                   '2020-01-15', '2020-01-30',       NA,        2
     ) %>% util$prefix_columns('cycle')
 
     response_tbl <- tribble(

--- a/tests/testthat/test_summarize_copilot.R
+++ b/tests/testthat/test_summarize_copilot.R
@@ -534,16 +534,13 @@ describe('map_responses_to_cycles', {
     triton.cycle <- tribble(
       ~uid,       ~team_id,     ~start_date,  ~extended_end_date,    ~ordinal,  ~extended_start_date,
       'Cycle_1',  'Team_Viper', '2020-01-01', '2020-01-14',          1,         '2019-06-30',
-      'Cycle_2',  'Team_Viper', '2020-01-15', '2020-01-30',          2,         '',
-      'Cycle_3',  'Team_Fox',   '2020-01-01', '2020-01-14',          1,         '',
-      'Cycle_4',  'Team_Fox',   '2020-01-15', '2020-01-30',          2,         '',
+      'Cycle_2',  'Team_Viper', '2020-01-15', '2020-01-30',          2,         ''
     ) %>% util$prefix_columns('cycle')
 
     response_tbl <- tribble(
       ~participant_id, ~created,              ~code,
       'Participant_1', '2019-12-31 12:00:00', 'trout viper', # Team Viper
-      'Participant_2', '2020-01-15 12:00:00', 'bass viper', # Team Viper
-      'Participant_3', '2020-01-01 12:00:00', 'fancy fox' # Team Fox
+      'Participant_2', '2020-01-15 12:00:00', 'bass viper' # Team Viper
     )
 
     # prove that participant_1's response falls outside the start_date, but
@@ -586,16 +583,13 @@ describe('map_responses_to_cycles', {
     triton.cycle <- tribble(
       ~uid,       ~team_id,     ~start_date,  ~extended_end_date,    ~ordinal,  ~extended_start_date,
       'Cycle_1',  'Team_Viper', '',           '2020-01-14',          1,         '2019-06-30',
-      'Cycle_2',  'Team_Viper', '2020-01-15', '2020-01-30',          2,         '',
-      'Cycle_3',  'Team_Fox',   '2020-01-01', '2020-01-14',          1,         '',
-      'Cycle_4',  'Team_Fox',   '2020-01-15', '2020-01-30',          2,         '',
+      'Cycle_2',  'Team_Viper', '2020-01-15', '2020-01-30',          2,         ''
     ) %>% util$prefix_columns('cycle')
 
     response_tbl <- tribble(
       ~participant_id, ~created,              ~code,
       'Participant_1', '2020-01-01 12:00:00', 'trout viper', # Team Viper
       'Participant_2', '2020-01-15 12:00:00', 'bass viper', # Team Viper
-      'Participant_3', '2020-01-01 12:00:00', 'fancy fox' # Team Fox
     )
 
     # now prove that the response is assigned to cycle 1, based on the


### PR DESCRIPTION
# Introduction

Implements support for extended start dates, to bring reports into line with updates to the Datateer dashboard.

# Implementation

d508338 adds an `extended_start_date` field to the `map_responses_to_cycles()` function and to accompanying test data.

# Testing

+ At commit d508338, all previous unit tests still pass, which indicates the changes have not altered previously documented and tested behavior of the function. This means, when `extended_start_date` is blank, the function still uses the value in the `start_date` field.
+ 13ee6aa proves that the function assigns priority to `extended_start_date` over `start_date` when both values are present.
+ 1784a75 proves that the `extended_start_date` field is used when `start_date` is absent.