### PR TITLE
Fix getting classrooms of empty networks

### DIFF
--- a/R/summarize_copilot.R
+++ b/R/summarize_copilot.R
@@ -604,7 +604,9 @@ get_classrooms_from_network <- function (network_ids,
   # Long form relationship table, unique by network-child
   network_assc <- triton.network %>%
     filter(network.uid %in% network_ids) %>%
-    json_utils$expand_string_array_column(network.association_ids)
+    json_utils$expand_string_array_column(network.association_ids) %>%
+    # Drop any networks that had no associations.
+    filter(!is.na(network.association_ids))
 
   # Structure of df to return.
   classroom_assc <- tibble(


### PR DESCRIPTION
## Background

RServe failed yesterday because there was a network with an empty set of `association_ids`. That caused an `NA` to be passed to a function which expected a string:

```
perts_ids$get_kind(): not a long uid, no underscore
```

## Implementation

I filtered `NA` values out of the network association df before continuing to work with it.

## Testing

Ran RServe locally after the fix and it got to the first report. All tests pass.

