### PR TITLE
Set connection charset

### DIFF
--- a/R/sql.R
+++ b/R/sql.R
@@ -4,7 +4,7 @@ util <- import_module("util")
 
 connect <- function(server_ip, dbname = NA, ssl_file_names = list(),
                     ssl_credentials = list(), password = NULL,
-                    mysql_user = "readonly") {
+                    mysql_user = "readonly", charset = 'utf8mb4') {
   # Get a connection to a MySQL database.
   #
   # Args:
@@ -20,6 +20,8 @@ connect <- function(server_ip, dbname = NA, ssl_file_names = list(),
   #   password - scalar character, optional password to use
   #   mysql_user - scalar character, default "readonly", name of mysql user
   #     account to use
+  #   charset - scalar character, default "utf8mb4", which is PERTS-standard and
+  #     used in triton and saturn dbs.
 
   CNF_PATH <- paste0(getwd(), "/sql_connect.tmp.cnf")
   SERVER_PORT <- 3306
@@ -97,6 +99,9 @@ connect <- function(server_ip, dbname = NA, ssl_file_names = list(),
       unlink(path, force = T)
     }
   }
+
+  safe_charset <- RMySQL::dbEscapeStrings(conn, charset)
+  DBI::dbGetQuery(conn, paste0("SET CHARSET '", safe_charset, "';"))
 
   return(conn)
 }


### PR DESCRIPTION
## Background

Addresses https://github.com/PERTS/rserve/issues/210

## Implementation

The "<92>" stuff was showing up from the very moment the data entered R, directly from the database query result. I checked our other tech that sets up db connections and found everything else is being explicit about the "character set" or "charset" to use to transfer data. It should be `utf8mb4`, which is NOT the default (although it should be, MySQL is dumb, blah blah).

The fix was to also be explicit on this when R connects. Thankfully, we have a centralized module for all our db connections! I added the necessary command, but also left it as a parameter in case we're dealing with some other db that isn't as on top of best practices as PERTS is in terms of emojis 😇.

Actually, **important question**: does the research team use `import_module('sql')` to make any non-PERTS db connections? Because this may affect those.
## Testing

I re-ran the [test report that has non-ascii characters](https://copilot.perts.net/groups/X7pz74jh5S3O0pL1/reports/rnNLiIx8zyuX0NeD/classes/LTqiAeIYiecq7pEL/elevate21_project/2022-02-21.html).

## Deployment

There will be another PR to handle Rserve.

