### PR TITLE
Recently modified rosters

### DIFF
--- a/tests/testthat/test_summarize_copilot.R
+++ b/tests/testthat/test_summarize_copilot.R
@@ -760,9 +760,10 @@ describe('recently_modified_rosters', {
   )
 
   some_modified <- dplyr::tibble(
-    participant.team_id = c('Team_B', 'Team_C', 'Team_D'),
+    participant.team_id = c('Team_B', 'Team_B', 'Team_C', 'Team_D'),
     participant.modified = c(
       '2021-01-07 00:00:00', # threshold exactly, thus recent
+      '2021-01-08 06:00:00', # after threshold, thus recent
       '2021-01-08 06:00:00', # after threshold, thus recent
       '2021-01-04 06:00:00' # not recent
     ),
@@ -787,6 +788,7 @@ describe('recently_modified_rosters', {
       time_lag_threshold
     )
 
+    # Despite multiple participants in these teams, the list should be unique.
     expect_equal(team_ids, c('Team_B', 'Team_C'))
   })
 })


### PR DESCRIPTION
## Background

Addresses https://github.com/PERTS/rserve/issues/266

Incorporated into https://github.com/PERTS/rserve/pull/268

## Implementation

To support code in the metascript, adds function `recently_modified_rosters()`. This simply looks at the modified field of the participant table, which tells us everything we need to know. Repeating the comments from that function:

```
  # The conventions of triton/Copilot allow us to detect ANY roster change by
  # looking at the `modified` field, which uses the MySQL clause
  # `ON UPDATE CURRENT_TIMESTAMP`:
  # * Adding a participant will set modified to the current time
  # * Removing a participant will _update_ the participant to be in zero
  #   classrooms, while still on the team, and thus update the modified time.
  # * Renaming a participant will update the modified time.
```
In other words because (1) participants are not truly deleted, but rather disassociated from classrooms while preserving their association with the team and (2) the database already updates the modified time on row creation or update, `modified` is all we need.

## Testing

Unit tests included.

