### PR TITLE
274 recent orgs

### DIFF
--- a/R/saturn.R
+++ b/R/saturn.R
@@ -123,7 +123,16 @@ create_service <- function (
   }
 
   get_responses <- function (...) {
+    qa_codes <- c(
+      'BASIC1',
+      'BASIC2',
+      'OVERLAP1',
+      'OVERLAP2',
+      'OVERLAP3'
+    )
+
     wide <- get_raw_responses(...) %>%
+      dplyr::filter(!code %in% qa_codes) %>%
       # It's typical for these to be duplicated with data in meta; rename to
       # prevent collision. We'll check sanity on them next and clean up.
       dplyr::rename(

--- a/R/summarize_copilot.R
+++ b/R/summarize_copilot.R
@@ -734,3 +734,22 @@ recently_modified_rosters <- function (triton.participant, report_date, time_lag
 
   return(modified_roster_team_ids)
 }
+
+recently_created_orgs <- function (
+  triton.organization,
+  report_date,
+  time_lag_threshold
+) {
+  # length-1 character, YYYY-MM-DD format
+  threshold <- as.character(
+    as.POSIXct(report_date) - as.difftime(time_lag_threshold, units="days"))
+
+  # Created times are in YYYY-MM-DD HH:mm:ss format, so we can use alphabetic
+  # string comparison to the threshold.
+  modified_org_ids <- triton.organization %>%
+    dplyr::filter(organization.created > threshold) %>%
+    dplyr::pull(organization.uid) %>%
+    unique()
+
+  return(modified_org_ids)
+}


### PR DESCRIPTION
Addresses https://github.com/PERTS/rserve/issues/274

9ce4402164991234d79c0aaa30837586d7ff2eea creates a function we'll need to solve the issue. Unit tests included.

f478ad2e866f89f31e83e23bc6c38c68d0c66092 is an older commit I never had QA'd. I inserted some responses into Saturn for testing dashboards in production, but they're not as well formed as they should be. Instead of fixing the responses, I just had RServe ignore them. Make me run a lap if you must, but I couldn't justify spending more than a second on appeasing RServe.