### PR TITLE
Adjustments to accommodate new GCloud SQL auth proxy

### DIFF
--- a/R/saturn.R
+++ b/R/saturn.R
@@ -17,7 +17,7 @@ json_utils <- import_module("json_utils")
 logging <- import_module("logging")
 sql <- import_module("sql")
 
-IP_ANALYSIS_REPLICA <- '34.66.52.115'
+IP_ANALYSIS_REPLICA <- '127.0.0.1'
 IP_LOCALHOST <- '127.0.0.1'
 
 create_service <- function (

--- a/R/saturn.R
+++ b/R/saturn.R
@@ -9,6 +9,10 @@
 #
 # * saturn_service$get_responses(survey_label) - returns a data frame
 
+# NOTE: In order to access our databases, you must first follow the instructions
+# for connecting to production databases, here:
+# https://docs.google.com/document/d/184dsSF-esWgJ-TS_da3--UkFNb1oIur-r99X-7Xmhfg/edit#heading=h.upesquweiol3
+
 # packages: dplyr, lubridate
 
 modules::import('dplyr', `%>%`)

--- a/R/saturn.R
+++ b/R/saturn.R
@@ -62,7 +62,8 @@ create_service <- function (
       dbname = db_name,
       ssl_credentials = ssl_credentials,
       password = password,
-      mysql_user = mysql_user
+      mysql_user = mysql_user,
+      port = 3421
     )
 
     safe_survey_label <- conn$escape_strings(survey_label)

--- a/R/sql.R
+++ b/R/sql.R
@@ -4,7 +4,8 @@ util <- import_module("util")
 
 connect <- function(server_ip, dbname = NA, ssl_file_names = list(),
                     ssl_credentials = list(), password = NULL,
-                    mysql_user = "readonly", charset = 'utf8mb4') {
+                    mysql_user = "readonly", charset = 'utf8mb4',
+                    SERVER_PORT = port) {
   # Get a connection to a MySQL database.
   #
   # Args:
@@ -24,7 +25,6 @@ connect <- function(server_ip, dbname = NA, ssl_file_names = list(),
   #     used in triton and saturn dbs.
 
   CNF_PATH <- paste0(getwd(), "/sql_connect.tmp.cnf")
-  SERVER_PORT <- 3306
 
   # These will be deleted as soon as they're not needed.
   temporary_file_paths <- CNF_PATH
@@ -228,7 +228,8 @@ create_triton_service <- function() {
     ),
     mysql_user = "readonly",
     password_file_name = "triton_replica_readonly_password.txt",
-    password = NULL
+    password = NULL,
+    port = 3411
   ))
 }
 

--- a/R/sql.R
+++ b/R/sql.R
@@ -1,5 +1,9 @@
 # packages: DBI, RMySQL
 
+# NOTE: In order to access our databases, you must first follow the instructions
+# for connecting to production databases, here:
+# https://docs.google.com/document/d/184dsSF-esWgJ-TS_da3--UkFNb1oIur-r99X-7Xmhfg/edit#heading=h.upesquweiol3
+
 util <- import_module("util")
 
 connect <- function(server_ip, dbname = NA, ssl_file_names = list(),

--- a/R/sql.R
+++ b/R/sql.R
@@ -219,7 +219,7 @@ create_neptune_service <- function() {
 create_triton_service <- function() {
   # Requires that perts_crypt.vc be mounted.
   return(create_service(
-    server_ip = "35.188.76.62",
+    server_ip = "127.0.0.1",
     dbname = "triton",
     ssl_file_names = list(
       ca = "triton_sql_production-01-analysis-replica.ca",

--- a/R/sql.R
+++ b/R/sql.R
@@ -5,7 +5,7 @@ util <- import_module("util")
 connect <- function(server_ip, dbname = NA, ssl_file_names = list(),
                     ssl_credentials = list(), password = NULL,
                     mysql_user = "readonly", charset = 'utf8mb4',
-                    SERVER_PORT = port) {
+                    port = NULL) {
   # Get a connection to a MySQL database.
   #
   # Args:
@@ -62,7 +62,7 @@ connect <- function(server_ip, dbname = NA, ssl_file_names = list(),
     user = mysql_user,
     dbname = dbname,
     host = server_ip,
-    port = SERVER_PORT
+    port = port
   )
 
   # If we're using a password, add it to the arguments.


### PR DESCRIPTION
Because of updates to our database storage/firewalls, the old method of connecting to Triton and Saturn databases will no longer work for analysts. In order to access these data now, analysts will have to connect to the databases via terminal first (instructions [here](https://docs.google.com/document/d/184dsSF-esWgJ-TS_da3--UkFNb1oIur-r99X-7Xmhfg/edit)), and only once they have established a connection via an open terminal, use the normal data loading functions in R. Moreover, there are a couple of tweaks that had to be implemented in the R code to accommodate this new process; thus this PR. These changes include (1) changing the IP address for Triton and Saturn to the localhost server, and (2) specifying the port numbers for Triton and Saturn. These port numbers align with the script used in the terminal to connect to the databases. 

A couple of considerations:
- Once we implement this, I don't think analysts will be able to access any Triton or Saturn data without using the terminal to connect to GCloud
- Port numbers are hard-coded in here, which shouldn't be a problem so long as we don't change them in the script that we use to connect via the terminal
- Are there other databases that analysts will need to access that we need to accommodate here? (Neptune?)